### PR TITLE
Build and release documentation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@
 * Breaking: EventFlow has switched to Paket templates for NuGet package creation in
   order to easier mange dependencies and dependencies are now slightly more
   restrictive
+* New: Documentation is now released in HTML format along with NuGet packages.
+  Access the ZIP file from the GitHub releases page
 
 ### New in 0.36.2315 (released 2016-10-18)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ deploy:
     on:
       branch: master
   - provider: GitHub
-    artifact: /.*\.nupkg/
+    artifact: /.*\.(nupkg|zip)/
     auth_token:
       secure: f+y+RL1ETsxIbYKlliZrmXpfr1wvEVNhGGEOYyl2K8ryz02WxXL+kLe7pu53Kc8r
     tag: v$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,14 @@ init:
 
 version: 0.37.{build}
 
+install:
+  - cmd: pip install -U Sphinx
+  - cmd: install sphinx_rtd_theme
+
 skip_tags: true
 
 build_script:
-  - cmd: build.cmd
+  - cmd: build.cmd All
 
 environment:
   RABBITMQ_URL:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ test: off
 
 artifacts:
   - path: Build\Packages\*.nupkg
+  - path: Build\Documentation\*.zip
 
 cache:
   - packages -> paket.lock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ version: 0.37.{build}
 
 install:
   - cmd: pip install -U Sphinx
-  - cmd: install sphinx_rtd_theme
+  - cmd: pip install sphinx_rtd_theme
 
 skip_tags: true
 

--- a/build.cmd
+++ b/build.cmd
@@ -10,6 +10,6 @@ IF %errorlevel% NEQ 0 (
 	exit /b %errorlevel%
 )
 
-"packages\build\Cake\Cake.exe" build.cake -nugetApikey=%NUGET_APIKEY% -buildVersion=%APPVEYOR_BUILD_VERSION%
+"packages\build\Cake\Cake.exe" build.cake -nugetApikey=%NUGET_APIKEY% -buildVersion=%APPVEYOR_BUILD_VERSION% -target=%1
 
 exit /b %errorlevel%

--- a/paket.lock
+++ b/paket.lock
@@ -52,7 +52,7 @@ REDIRECTS: OFF
 FRAMEWORK: NET451
 NUGET
   remote: https://www.nuget.org/api/v2
-    Cake (0.13)
+    Cake (0.16.2)
     GitVersion.CommandLine (3.5.4)
     ilmerge (2.14.1208)
     NUnit.ConsoleRunner (3.4.1)


### PR DESCRIPTION
Currently the finished documentation is only available on the Read the Docs site. This PR will make sure the documentation is released along with the EventFlow NuGet packages.