### PR TITLE
Update GettingStarted.rst

### DIFF
--- a/Documentation/GettingStarted.rst
+++ b/Documentation/GettingStarted.rst
@@ -156,7 +156,7 @@ command arguments.
 .. code-block:: c#
 
     public class UserCreateCommand :
-      ICommand<UserAggregate, UserId, UserCreateCommand>
+      CommandHandler<UserAggregate, UserId, UserCreateCommand>
     {
       public Task ExecuteAsync(
         UserAggregate aggregate,


### PR DESCRIPTION
Under the "Create command handler" section, the implemented base class should have been CommandHandler instead of ICommand