### PR TITLE
Fix EventId generation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 ### New in 0.42 (not released yet)
 
-* _Nothing yet_
+* Fixed: The deterministic `IDomainEvent.Metadata.EventId` is now correctly
+  based on the both the aggregate identity and the aggregate sequence number,
+  instead of merely the aggregate identity
 
 ### New in 0.41.2727 (released 2017-04-27)
 

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
@@ -127,7 +127,7 @@ namespace EventFlow.Tests.UnitTests.Aggregates
             eventIdGuids[0]
                 .Should()
                 .Be("event-3dde5ccb-b594-59b4-ad0a-4d432ffce026");
-            // GuidFactories.Deterministic.Namespaces.Events, $"{thingyId.Value}-v1"
+            // GuidFactories.Deterministic.Namespaces.Events, $"{thingyId.Value}-v2"
             eventIdGuids[1]
                 .Should()
                 .Be("event-2e79868f-6ef7-5c88-a941-12ae7ae801c7");

--- a/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Aggregates/AggregateRootTests.cs
@@ -23,6 +23,7 @@
 
 using System.Linq;
 using EventFlow.Aggregates;
+using EventFlow.Core;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Events;
@@ -92,6 +93,44 @@ namespace EventFlow.Tests.UnitTests.Aggregates
 
             // Assert
             Sut.DomainErrorAfterFirstReceived.Should().BeTrue();
+        }
+
+        [Test]
+        public void UncomittedEventIdsShouldBeDistinct()
+        {
+            // Act
+            Sut.Ping(A<PingId>());
+            Sut.Ping(A<PingId>());
+
+            // Assert
+            Sut.UncommittedEvents
+                .Select(e => e.Metadata.EventId).Distinct()
+                .Should().HaveCount(2);
+        }
+
+        [Test]
+        public void UncomittedEventIdsShouldBeDeterministic()
+        {
+            // Arrange
+            Inject(ThingyId.With("thingy-75e925aa-9b01-4615-89ee-2a2ecf91d7e8"));
+
+            // Act
+            Sut.Ping(A<PingId>());
+            Sut.Ping(A<PingId>());
+
+            // Assert
+            var eventIdGuids = Sut.UncommittedEvents
+                .Select(e => e.Metadata.EventId.Value)
+                .ToList();
+
+            // GuidFactories.Deterministic.Namespaces.Events, $"{thingyId.Value}-v1"
+            eventIdGuids[0]
+                .Should()
+                .Be("event-3dde5ccb-b594-59b4-ad0a-4d432ffce026");
+            // GuidFactories.Deterministic.Namespaces.Events, $"{thingyId.Value}-v1"
+            eventIdGuids[1]
+                .Should()
+                .Be("event-2e79868f-6ef7-5c88-a941-12ae7ae801c7");
         }
 
         [Test]

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -46,7 +46,7 @@ namespace EventFlow.Aggregates
         public TIdentity Id { get; }
         public int Version { get; protected set; }
         public bool IsNew => Version <= 0;
-        public IEnumerable<IAggregateEvent> UncommittedEvents { get { return _uncommittedEvents.Select(e => e.AggregateEvent); } }
+        public IEnumerable<IUncommittedEvent> UncommittedEvents => _uncommittedEvents;
 
         static AggregateRoot()
         {

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -86,7 +86,7 @@ namespace EventFlow.Aggregates
             var aggregateSequenceNumber = Version + 1;
             var eventId = EventId.NewDeterministic(
                 GuidFactories.Deterministic.Namespaces.Events,
-                $"{Id.Value}-v{0}");
+                $"{Id.Value}-v{aggregateSequenceNumber}");
             var now = DateTimeOffset.Now;
             var eventMetadata = new Metadata
                 {

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -34,7 +34,7 @@ namespace EventFlow.Aggregates
     {
         IAggregateName Name { get; }
         int Version { get; }
-        IEnumerable<IAggregateEvent> UncommittedEvents { get; }
+        IEnumerable<IUncommittedEvent> UncommittedEvents { get; }
         bool IsNew { get; }
 
         Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(IEventStore eventStore, ISnapshotStore snapshotStore, ISourceId sourceId, CancellationToken cancellationToken);


### PR DESCRIPTION
EventId was by mistake only based on the aggregate ID, making the ID the same for every single event emitted.

Fixes #325