### PR TITLE
When validating registrations, a lifetime scope should be used

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 ### New in 0.46 (not released yet)
 
-* _Nothing yet_
+* Fix: EventFlow now uses a Autofac lifetime scope for validating service
+  registrations when `IEventFlowOpions.CreateResolver(true)` is invoked.
+  Previously services were created but never disposed as they were resolved
+  using the root container
 
 ### New in 0.45.2877 (released 2017-05-28)
 

--- a/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
+++ b/Source/EventFlow.Autofac.Tests/UnitTests/AutofacServiceRegistrationTests.cs
@@ -25,6 +25,8 @@ using EventFlow.Autofac.Registrations;
 using EventFlow.Configuration;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Suites;
+using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 
 namespace EventFlow.Autofac.Tests.UnitTests
@@ -32,6 +34,40 @@ namespace EventFlow.Autofac.Tests.UnitTests
     [Category(Categories.Unit)]
     public class AutofacServiceRegistrationTests : TestSuiteForServiceRegistration
     {
+        [Test]
+        public void ValidateRegistrationsShouldDispose()
+        {
+            // Arrange
+            var service = new Mock<I>();
+            var createdCount = 0;
+            Sut.Register(_ =>
+                {
+                    createdCount++;
+                    return service.Object;
+                });
+
+            // Act and Assert
+            using (var resolver = Sut.CreateResolver(true))
+            {
+                createdCount.Should().Be(1);
+                service.Verify(m => m.Dispose(), Times.Once);
+
+                var resolvedService = resolver.Resolve<I>();
+                createdCount.Should().Be(2);
+                resolvedService.Should().BeSameAs(service.Object);
+
+                using (var scopedResolver = resolver.BeginScope())
+                {
+                    var nestedResolvedService = scopedResolver.Resolve<I>();
+                    createdCount.Should().Be(3);
+                    nestedResolvedService.Should().BeSameAs(service.Object);
+                }
+                service.Verify(m => m.Dispose(), Times.Exactly(2));
+            }
+
+            service.Verify(m => m.Dispose(), Times.Exactly(3));
+        }
+
         protected override IServiceRegistration CreateSut()
         {
             return new AutofacServiceRegistration();

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
@@ -187,7 +187,7 @@ namespace EventFlow.TestHelpers.Suites
             Sut.Register<I, A>();
 
             // Act
-            var resolver = Sut.CreateResolver(true);
+            var resolver = Sut.CreateResolver(false);
             var i1 = resolver.Resolve<I>();
             var i2 = resolver.Resolve<I>();
 

--- a/Source/EventFlow/Extensions/ResolverExtensions.cs
+++ b/Source/EventFlow/Extensions/ResolverExtensions.cs
@@ -31,18 +31,21 @@ namespace EventFlow.Extensions
     public static class ResolverExtensions
     {
         public static void ValidateRegistrations(
-            this IResolver resolver)
+            this IRootResolver resolver)
         {
             var exceptions = new List<Exception>();
-            foreach (var type in resolver.GetRegisteredServices())
+            using (var scopeResolver = resolver.BeginScope())
             {
-                try
+                foreach (var type in scopeResolver.GetRegisteredServices())
                 {
-                    resolver.Resolve(type);
-                }
-                catch (Exception ex)
-                {
-                    exceptions.Add(ex);
+                    try
+                    {
+                        scopeResolver.Resolve(type);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #340