### PR TITLE
Removed the new() constraint on read models

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ### New in 0.51 (not released yet)
 
-* _Nothing yet_
+* New: Removed the `new()` requirement for read models
 
 ### New in 0.50.3124 (released 2017-10-21)
 

--- a/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.Elasticsearch/Extensions/EventFlowOptionsExtensions.cs
@@ -76,7 +76,7 @@ namespace EventFlow.Elasticsearch.Extensions
 
         public static IEventFlowOptions UseElasticsearchReadModel<TReadModel>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return eventFlowOptions
                 .RegisterServices(f =>
@@ -89,7 +89,7 @@ namespace EventFlow.Elasticsearch.Extensions
 
         public static IEventFlowOptions UseElasticsearchReadModel<TReadModel, TReadModelLocator>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
             where TReadModelLocator : IReadModelLocator
         {
             return eventFlowOptions

--- a/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
@@ -38,7 +38,7 @@ namespace EventFlow.Elasticsearch.ReadStores
 {
     public class ElasticsearchReadModelStore<TReadModel> :
         IElasticsearchReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         private readonly ILog _log;
         private readonly IElasticClient _elasticClient;

--- a/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/IElasticsearchReadModelStore.cs
@@ -26,7 +26,7 @@ using EventFlow.ReadStores;
 namespace EventFlow.Elasticsearch.ReadStores
 {
     public interface IElasticsearchReadModelStore<TReadModel> : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
     }
 }

--- a/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.MsSql/Extensions/EventFlowOptionsMsSqlReadStoreExtensions.cs
@@ -33,7 +33,7 @@ namespace EventFlow.MsSql.Extensions
     {
         public static IEventFlowOptions UseMssqlReadModel<TReadModel, TReadModelLocator>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
             where TReadModelLocator : IReadModelLocator
         {
             return eventFlowOptions
@@ -48,7 +48,7 @@ namespace EventFlow.MsSql.Extensions
 
         public static IEventFlowOptions UseMssqlReadModel<TReadModel>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return eventFlowOptions
                 .RegisterServices(f =>

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -34,7 +34,7 @@ using Microsoft.SqlServer.Server;
 namespace EventFlow.MsSql.Integrations
 {
     internal class TableParameter<TRow> : SqlMapper.IDynamicParameters
-        where TRow : class, new()
+        where TRow : class
     {
         private readonly string _name;
         private readonly IEnumerable<TRow> _rows;

--- a/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/IMssqlReadModelStore.cs
@@ -26,7 +26,7 @@ using EventFlow.ReadStores;
 namespace EventFlow.MsSql.ReadStores
 {
     public interface IMssqlReadModelStore<TReadModel> : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
     }
 }

--- a/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
+++ b/Source/EventFlow.MsSql/ReadStores/MssqlReadModelStore.cs
@@ -42,7 +42,7 @@ namespace EventFlow.MsSql.ReadStores
     public class MssqlReadModelStore<TReadModel> :
         ReadModelStore<TReadModel>,
         IMssqlReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         private readonly IMsSqlConnection _connection;
         private readonly IReadModelSqlGenerator _readModelSqlGenerator;

--- a/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.SQLite/Extensions/EventFlowOptionsExtensions.cs
@@ -57,7 +57,7 @@ namespace EventFlow.SQLite.Extensions
 
         public static IEventFlowOptions UseSQLiteReadModel<TReadModel, TReadModelLocator>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
             where TReadModelLocator : IReadModelLocator
         {
             return eventFlowOptions
@@ -72,7 +72,7 @@ namespace EventFlow.SQLite.Extensions
 
         public static IEventFlowOptions UseSQLiteReadModel<TReadModel>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return eventFlowOptions
                 .RegisterServices(f =>

--- a/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/ISQLiteReadModelStore.cs
@@ -27,7 +27,7 @@ using EventFlow.Sql.ReadModels;
 namespace EventFlow.SQLite.ReadStores
 {
     public interface ISQLiteReadModelStore<TReadModel> : ISqlReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
     }
 }

--- a/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
+++ b/Source/EventFlow.SQLite/ReadStores/SQLiteReadModelStore.cs
@@ -29,7 +29,7 @@ using EventFlow.SQLite.Connections;
 namespace EventFlow.SQLite.ReadStores
 {
     public class SQLiteReadModelStore<TReadModel> : SqlReadModelStore<ISQLiteConnection, TReadModel>, ISQLiteReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         public SQLiteReadModelStore(
             ILog log,

--- a/Source/EventFlow.Sql/Connections/ISqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/ISqlConnection.cs
@@ -49,7 +49,7 @@ namespace EventFlow.Sql.Connections
             CancellationToken cancellationToken,
             string sql,
             IEnumerable<TRow> rows)
-            where TRow : class, new();
+            where TRow : class;
 
         Task<TResult> WithConnectionAsync<TResult>(
             Label label,

--- a/Source/EventFlow.Sql/Connections/SqlConnection.cs
+++ b/Source/EventFlow.Sql/Connections/SqlConnection.cs
@@ -95,7 +95,7 @@ namespace EventFlow.Sql.Connections
             CancellationToken cancellationToken,
             string sql,
             IEnumerable<TRow> rows)
-            where TRow : class, new()
+            where TRow : class
         {
             Log.Debug(
                 "Insert multiple not optimised, inserting one row at a time using SQL '{0}'",

--- a/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/ISqlReadModelStore.cs
@@ -26,7 +26,7 @@ using EventFlow.ReadStores;
 namespace EventFlow.Sql.ReadModels
 {
     public interface ISqlReadModelStore<TReadModel> : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
     }
 }

--- a/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
@@ -40,7 +40,7 @@ namespace EventFlow.Sql.ReadModels
     public abstract class SqlReadModelStore<TSqlConnection, TReadModel> :
         ReadModelStore<TReadModel>,
         ISqlReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
         where TSqlConnection : ISqlConnection
     {
         private readonly TSqlConnection _connection;

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelFactoryTests.cs
@@ -21,12 +21,18 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EventFlow.Logs;
 using EventFlow.ReadStores;
 using EventFlow.TestHelpers;
 using FluentAssertions;
 using NUnit.Framework;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedMember.Global
 
 namespace EventFlow.Tests.UnitTests.ReadStores
 {
@@ -61,6 +67,23 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             }
         }
 
+        [Test]
+        public void ThrowsExceptionForNoEmptyConstruuctors()
+        {
+            // Act + Assert
+            var exception = Assert.Throws<TypeInitializationException>(() => new ReadModelFactory<ReadModelWithConstructorArguments>(Mock<ILog>()));
+            
+            // Assert
+            // ReSharper disable once PossibleNullReferenceException
+            exception.InnerException.Message.Should().Contain("doesn't have an empty constructor");
+        }
+
+        public class ReadModelWithConstructorArguments : IReadModel
+        {
+            // ReSharper disable once UnusedParameter.Local
+            public ReadModelWithConstructorArguments(int magicNumber){ }
+        }
+        
         public interface IFancyReadModel : IReadModel
         {
             int MagicNumber { get; set; }

--- a/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsReadStoresExtensions.cs
@@ -35,7 +35,7 @@ namespace EventFlow.Extensions
         public static IEventFlowOptions UseReadStoreFor<TReadStore, TReadModel>(
             this IEventFlowOptions eventFlowOptions)
             where TReadStore : class, IReadModelStore<TReadModel>
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return eventFlowOptions.RegisterServices(f =>
                 {
@@ -47,7 +47,7 @@ namespace EventFlow.Extensions
         public static IEventFlowOptions UseReadStoreFor<TReadStore, TReadModel, TReadModelLocator>(
             this IEventFlowOptions eventFlowOptions)
             where TReadStore : class, IReadModelStore<TReadModel>
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
             where TReadModelLocator : IReadModelLocator
         {
             return eventFlowOptions.RegisterServices(f =>
@@ -59,7 +59,7 @@ namespace EventFlow.Extensions
 
         public static IEventFlowOptions UseInMemoryReadStoreFor<TReadModel>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return eventFlowOptions
                 .RegisterServices(f =>
@@ -73,7 +73,7 @@ namespace EventFlow.Extensions
 
         public static IEventFlowOptions UseInMemoryReadStoreFor<TReadModel, TReadModelLocator>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
             where TReadModelLocator : IReadModelLocator
         {
             return eventFlowOptions

--- a/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
+++ b/Source/EventFlow/Extensions/ReadModelPopulatorExtensions.cs
@@ -33,7 +33,7 @@ namespace EventFlow.Extensions
         public static void Purge<TReadModel>(
             this IReadModelPopulator readModelPopulator,
             CancellationToken cancellationToken)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             using (var a = AsyncHelper.Wait)
             {
@@ -55,7 +55,7 @@ namespace EventFlow.Extensions
         public static void Populate<TReadModel>(
             this IReadModelPopulator readModelPopulator,
             CancellationToken cancellationToken)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             using (var a = AsyncHelper.Wait)
             {

--- a/Source/EventFlow/Queries/ReadModelByIdQuery.cs
+++ b/Source/EventFlow/Queries/ReadModelByIdQuery.cs
@@ -30,7 +30,7 @@ using EventFlow.ReadStores;
 namespace EventFlow.Queries
 {
     public class ReadModelByIdQuery<TReadModel> : IQuery<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         public string Id { get; }
 
@@ -49,7 +49,7 @@ namespace EventFlow.Queries
 
     public class ReadModelByIdQueryHandler<TReadStore, TReadModel> : IQueryHandler<ReadModelByIdQuery<TReadModel>, TReadModel>
         where TReadStore : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         private readonly TReadStore _readStore;
 

--- a/Source/EventFlow/ReadStores/IReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelFactory.cs
@@ -27,7 +27,7 @@ using System.Threading.Tasks;
 namespace EventFlow.ReadStores
 {
     public interface IReadModelFactory<TReadModel>
-        where TReadModel : IReadModel, new()
+        where TReadModel : IReadModel
     {
         Task<TReadModel> CreateAsync(string id, CancellationToken cancellationToken);
     }

--- a/Source/EventFlow/ReadStores/IReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/IReadModelPopulator.cs
@@ -30,10 +30,10 @@ namespace EventFlow.ReadStores
     public interface IReadModelPopulator
     {
         Task PurgeAsync<TReadModel>(CancellationToken cancellationToken)
-            where TReadModel : class, IReadModel, new();
+            where TReadModel : class, IReadModel;
 
         Task PopulateAsync<TReadModel>(CancellationToken cancellationToken)
-            where TReadModel : class, IReadModel, new();
+            where TReadModel : class, IReadModel;
 
         Task PopulateAsync(
             Type readModelType,

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -40,7 +40,7 @@ namespace EventFlow.ReadStores
     }
 
     public interface IReadModelStore<TReadModel> : IReadModelStore
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         Task<ReadModelEnvelope<TReadModel>> GetAsync(
             string id,

--- a/Source/EventFlow/ReadStores/IReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/IReadStoreManager.cs
@@ -39,7 +39,7 @@ namespace EventFlow.ReadStores
     }
 
     public interface IReadStoreManager<TReadModel> : IReadStoreManager
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
     }
 }

--- a/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/IInMemoryReadStore.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 namespace EventFlow.ReadStores.InMemory
 {
     public interface IInMemoryReadStore<TReadModel> : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         Task<IReadOnlyCollection<TReadModel>> FindAsync(
             Predicate<TReadModel> predicate,

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryQueryHandler.cs
@@ -31,7 +31,7 @@ namespace EventFlow.ReadStores.InMemory
 {
     public class InMemoryQueryHandler<TReadModel> :
         IQueryHandler<InMemoryQuery<TReadModel>, IReadOnlyCollection<TReadModel>>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         private readonly IInMemoryReadStore<TReadModel> _readModelStore;
 

--- a/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
+++ b/Source/EventFlow/ReadStores/InMemory/InMemoryReadStore.cs
@@ -33,7 +33,7 @@ using EventFlow.Logs;
 namespace EventFlow.ReadStores.InMemory
 {
     public class InMemoryReadStore<TReadModel> : ReadModelStore<TReadModel>, IInMemoryReadStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         private readonly Dictionary<string, ReadModelEnvelope<TReadModel>> _readModels = new Dictionary<string, ReadModelEnvelope<TReadModel>>();
         private readonly AsyncLock _asyncLock = new AsyncLock();

--- a/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
+++ b/Source/EventFlow/ReadStores/InMemory/Queries/InMemoryQuery.cs
@@ -28,7 +28,7 @@ using EventFlow.Queries;
 namespace EventFlow.ReadStores.InMemory.Queries
 {
     public class InMemoryQuery<TReadModel> : IQuery<IReadOnlyCollection<TReadModel>>
-        where TReadModel : IReadModel, new()
+        where TReadModel : IReadModel
     {
         public Predicate<TReadModel> Query { get; }
 

--- a/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/MultipleAggregateReadStoreManager.cs
@@ -34,7 +34,7 @@ namespace EventFlow.ReadStores
     public class MultipleAggregateReadStoreManager<TReadStore, TReadModel, TReadModelLocator> :
         ReadStoreManager<TReadStore, TReadModel>
         where TReadStore : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
         where TReadModelLocator : IReadModelLocator
     {
         private readonly TReadModelLocator _readModelLocator;

--- a/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
+++ b/Source/EventFlow/ReadStores/ReadModelEnvelope.cs
@@ -26,7 +26,7 @@ using System;
 namespace EventFlow.ReadStores
 {
     public class ReadModelEnvelope<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         private ReadModelEnvelope(
             string readModelId,

--- a/Source/EventFlow/ReadStores/ReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelFactory.cs
@@ -22,6 +22,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Extensions;
@@ -33,8 +35,24 @@ namespace EventFlow.ReadStores
         where TReadModel : IReadModel
     {
         private readonly ILog _log;
-        
-        // TODO: Check if read model has empty constructor
+
+        static ReadModelFactory()
+        {
+            var type = typeof(TReadModel).GetTypeInfo();
+
+            var emptyConstructor = type
+                .GetConstructors()
+                .Where(c => !c.GetParameters().Any())
+                .ToList();
+
+            if (!emptyConstructor.Any())
+            {
+                throw new ArgumentException(
+                    $"Read model type '{typeof(TReadModel).PrettyPrint()}' doesn't have an empty "+
+                    $"constructor. Please create a custom '{typeof(IReadModelFactory<TReadModel>).PrettyPrint()}' "+
+                    "implementation.");
+            }
+        }
 
         public ReadModelFactory(
             ILog log)

--- a/Source/EventFlow/ReadStores/ReadModelFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelFactory.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Extensions;
@@ -29,9 +30,11 @@ using EventFlow.Logs;
 namespace EventFlow.ReadStores
 {
     public class ReadModelFactory<TReadModel> : IReadModelFactory<TReadModel>
-        where TReadModel : IReadModel, new()
+        where TReadModel : IReadModel
     {
         private readonly ILog _log;
+        
+        // TODO: Check if read model has empty constructor
 
         public ReadModelFactory(
             ILog log)
@@ -43,7 +46,9 @@ namespace EventFlow.ReadStores
         {
             _log.Verbose(() => $"Creating new instance of read model type '{typeof(TReadModel).PrettyPrint()}' with ID '{id}'");
 
-            return Task.FromResult(new TReadModel());
+            var readModel = (TReadModel) Activator.CreateInstance(typeof(TReadModel));
+
+            return Task.FromResult(readModel);
         }
     }
 }

--- a/Source/EventFlow/ReadStores/ReadModelPopulator.cs
+++ b/Source/EventFlow/ReadStores/ReadModelPopulator.cs
@@ -56,7 +56,7 @@ namespace EventFlow.ReadStores
 
         public Task PurgeAsync<TReadModel>(
             CancellationToken cancellationToken)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return PurgeAsync(typeof(TReadModel), cancellationToken);
         }
@@ -86,7 +86,7 @@ namespace EventFlow.ReadStores
 
         public Task PopulateAsync<TReadModel>(
             CancellationToken cancellationToken)
-            where TReadModel : class, IReadModel, new()
+            where TReadModel : class, IReadModel
         {
             return PopulateAsync(typeof(TReadModel), cancellationToken);
         }

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -31,7 +31,7 @@ using EventFlow.Logs;
 namespace EventFlow.ReadStores
 {
     public abstract class ReadModelStore<TReadModel> : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         protected ILog Log { get; }
 

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -36,7 +36,7 @@ namespace EventFlow.ReadStores
 {
     public abstract class ReadStoreManager<TReadModelStore, TReadModel> : IReadStoreManager<TReadModel>
         where TReadModelStore : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         // ReSharper disable StaticMemberInGenericType
         private static readonly Type StaticReadModelType = typeof(TReadModel);

--- a/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/SingleAggregateReadStoreManager.cs
@@ -33,7 +33,7 @@ namespace EventFlow.ReadStores
 {
     public class SingleAggregateReadStoreManager<TReadModelStore, TReadModel> : ReadStoreManager<TReadModelStore, TReadModel>
         where TReadModelStore : IReadModelStore<TReadModel>
-        where TReadModel : class, IReadModel, new()
+        where TReadModel : class, IReadModel
     {
         public SingleAggregateReadStoreManager(
             ILog log,


### PR DESCRIPTION
After the introduction of the `IReadModelFactory` this requirement has been obsolete. Lets remove it and give more control to developers

Fixes #390