### PR TITLE
Allow LocateSagaAsync to return null

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 ### New in 0.51 (not released yet)
 
-* _Nothing yet_
+* New: If `ISagaLocator.LocateSagaAsync` cannot identify the saga for a given 
+  event, it may now return `Task.FromResult(null)` in order to short-circuit
+  the dispatching process. This might be useful in cases where some instances 
+  of an event belong to a saga process while others don't
 
 ### New in 0.50.3124 (released 2017-10-21)
 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
@@ -141,7 +141,13 @@ namespace EventFlow.Tests.IntegrationTests.Sagas
         {
             public Task<ISagaId> LocateSagaAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)
             {
-                return Task.FromResult<ISagaId>(new TestSagaId($"saga-for-{domainEvent.GetIdentity().Value}"));
+                var identity = domainEvent.GetIdentity().Value;
+                if (identity.EndsWith(Guid.Empty.ToString()))
+                {
+                    return Task.FromResult<ISagaId>(null);
+                }
+
+                return Task.FromResult<ISagaId>(new TestSagaId($"saga-for-{identity}"));
             }
         }
 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTestClasses.cs
@@ -32,6 +32,7 @@ using EventFlow.Commands;
 using EventFlow.Core;
 using EventFlow.Sagas;
 using EventFlow.ValueObjects;
+using FluentAssertions;
 
 namespace EventFlow.Tests.IntegrationTests.Sagas
 {
@@ -48,6 +49,12 @@ namespace EventFlow.Tests.IntegrationTests.Sagas
         {
             private readonly Dictionary<ISagaId, object> _sagas = new Dictionary<ISagaId, object>();
             private readonly AsyncLock _asyncLock = new AsyncLock();
+            private bool _hasUpdateBeenCalled;
+
+            public void UpdateShouldNotHaveBeenCalled()
+            {
+                this._hasUpdateBeenCalled.Should().BeFalse();
+            }
 
             public async Task<TSaga> UpdateAsync<TSaga>(
                 ISagaId sagaId,
@@ -59,10 +66,11 @@ namespace EventFlow.Tests.IntegrationTests.Sagas
             {
                 using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    object obj;
-                    if (!_sagas.TryGetValue(sagaId, out obj))
+                    _hasUpdateBeenCalled = true;
+
+                    if (!_sagas.TryGetValue(sagaId, out var obj))
                     {
-                        obj = Activator.CreateInstance(sagaDetails.SagaType, new object[] {sagaId});
+                        obj = Activator.CreateInstance(sagaDetails.SagaType, sagaId);
                         _sagas[sagaId] = obj;
                     }
 

--- a/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/Sagas/AlternativeSagaStoreTests.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Aggregates;
@@ -100,6 +101,16 @@ namespace EventFlow.Tests.IntegrationTests.Sagas
             testAggregate.As.Should().Be(0);
             testAggregate.Bs.Should().Be(1);
             testAggregate.Cs.Should().Be(0);
+        }
+
+        [Test]
+        public void SagaLocatorReturningNullDoesntThrow()
+        {
+            // Arrange
+            var aggregateId = AlternativeSagaStoreTestClasses.SagaTestAggregateId.With(Guid.Empty);
+
+            // Act
+            _commandBus.Publish(new AlternativeSagaStoreTestClasses.SagaTestBCommand(aggregateId), CancellationToken.None);
         }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
@@ -68,7 +68,10 @@ namespace EventFlow.Tests.UnitTests.Sagas
                 .Returns(_sagaUpdaterMock.Object);
             _sagaDefinitionServiceMock
                 .Setup(d => d.GetSagaDetails(It.IsAny<Type>()))
-                .Returns(new[] {SagaDetails.From(sagaType),});
+                .Returns(new[] {SagaDetails.From(sagaType)});
+            _sagaLocatorMock
+                .Setup(s => s.LocateSagaAsync(It.IsAny<IDomainEvent>(), CancellationToken.None))
+                .Returns(() => Task.FromResult<ISagaId>(new ThingySagaId(string.Empty)));
         }
 
         [Test]

--- a/Source/EventFlow/Sagas/DispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/DispatchToSagas.cs
@@ -83,6 +83,13 @@ namespace EventFlow.Sagas
             {
                 var locator = (ISagaLocator) _resolver.Resolve(details.SagaLocatorType);
                 var sagaId = await locator.LocateSagaAsync(domainEvent, cancellationToken).ConfigureAwait(false);
+
+                if (sagaId == null)
+                {
+                    _log.Verbose(() => $"Saga locator '{details.SagaLocatorType.Name}' returned null");
+                    continue;
+                }
+
                 var saga =  await ProcessSagaAsync(domainEvent, sagaId, details, cancellationToken).ConfigureAwait(false);
 
                 if (saga != null)

--- a/Source/EventFlow/Sagas/DispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/DispatchToSagas.cs
@@ -86,7 +86,7 @@ namespace EventFlow.Sagas
 
                 if (sagaId == null)
                 {
-                    _log.Verbose(() => $"Saga locator '{details.SagaLocatorType.Name}' returned null");
+                    _log.Verbose(() => $"Saga locator '{details.SagaLocatorType.PrettyPrint()}' returned null");
                     continue;
                 }
 


### PR DESCRIPTION
I have a use case where a specific event might be part of a saga, but can also happen independently: Accounts can be created "on demand" during a payment process (`PaymentSaga`), but they might also be created beforehand.

Every time the `PaymentSagaLocator` encounters a standalone instance of the `AccountCreated` event, it won't find any payment metadata and cannot extract a payment id. So it returns a new id, leading to the saga's initialization - only to be discarded soon as this event doesn't start the saga. This seems counterintuitive.

I added the possibility to return `null` instead in order to short circuit the saga dispatcher process, as that was what I tried to do in the first place.