### PR TITLE
FilesEventPersistence as singleton, added concurrency tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 ### New in 0.52 (not released yet)
 
-* _Nothing yet_
+* Fixed: `.UseFilesEventStore` now uses a thread safe singleton instance for 
+  file system persistence, making it suitable for use in multi-threaded unit
+  tests. Please don't use the files event store in production scenarios
 
 ### New in 0.51.3155 (released 2017-10-25)
 
@@ -10,7 +12,7 @@
   the dispatching process. This might be useful in cases where some instances 
   of an event belong to a saga process while others don't
 * Fixed: `StringExtensions.ToSha256()` can now be safely used from
-  concurrent threads.
+  concurrent threads
 
 ### New in 0.50.3124 (released 2017-10-21)
 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentFilesEventPersistanceTests.cs
@@ -1,0 +1,206 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2017 Rasmus Mikkelsen
+// Copyright (c) 2015-2017 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Core;
+using EventFlow.EventStores;
+using EventFlow.EventStores.Files;
+using EventFlow.Exceptions;
+using EventFlow.Logs;
+using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Events;
+using EventFlow.TestHelpers.Aggregates.ValueObjects;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.Tests.UnitTests.EventStores
+{
+    public class ConcurrentFilesEventPersistanceTests
+    {
+        private const int DegreeOfParallelism = 10;
+        private const int NumberOfEventsPerBatch = 10;
+
+        private static readonly ThingyId ThingyId = ThingyId.New;
+
+        private string _storeRootPath;
+        private EventJsonSerializer _serializer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var factory = new DomainEventFactory();
+            var definitionService = new EventDefinitionService(new NullLog());
+            definitionService.Load(typeof(ThingyPingEvent));
+
+            _serializer = new EventJsonSerializer(new JsonSerializer(), definitionService, factory);
+        }
+
+        [SetUp]
+        public void CreateStoreRootDir()
+        {
+            _storeRootPath = Path.Combine(
+                Path.GetTempPath(),
+                Guid.NewGuid().ToString());
+
+            Directory.CreateDirectory(_storeRootPath);
+        }
+
+        [TearDown]
+        public void DeleteStoreRootDir()
+        {
+            Directory.Delete(_storeRootPath, true);
+        }
+
+        [Test]
+        public void MultipleInstancesWithSamePathFail()
+        {
+            // Arrange
+            var tasks = RunInParallel(async i =>
+            {
+                var persistence = CreatePersistence("SameForAll");
+                await CommitEvents(persistence);
+            });
+
+            // Act
+            Action action = () => Task.WaitAll(tasks.ToArray());
+
+            // Assert
+            action.ShouldThrow<IOException>("because of concurrent access to the same files.");
+        }
+
+        [Test]
+        public void MultipleInstancesWithDifferentPathsWork()
+        {
+            // Arrange
+            var tasks = RunInParallel(async i =>
+            {
+                var persistence = CreatePersistence(i.ToString());
+                await CommitEvents(persistence);
+            });
+
+            // Act
+            Action action = () => Task.WaitAll(tasks.ToArray());
+
+            // Assert
+            action.ShouldNotThrow();
+        }
+
+        [Test]
+        public void SingleInstanceWorks()
+        {
+            // Arrange
+            var persistence = CreatePersistence();
+            var tasks = RunInParallel(async i =>
+            {
+                await CommitEvents(persistence);
+            });
+
+            // Act
+            Action action = () => Task.WaitAll(tasks.ToArray());
+
+            // Assert
+            action.ShouldNotThrow();
+        }
+
+        private IFilesEventStoreConfiguration ConfigurePath(string storePath)
+        {
+            var fullPath = Path.Combine(_storeRootPath, storePath);
+            return FilesEventStoreConfiguration.Create(fullPath);
+        }
+
+        private FilesEventPersistence CreatePersistence(string storePath = "")
+        {
+            var log = new NullLog();
+            var serializer = new JsonSerializer();
+            var config = ConfigurePath(storePath);
+            var locator = new FilesEventLocator(config);
+            return new FilesEventPersistence(log, serializer, config, locator);
+        }
+
+        private async Task CommitEvents(FilesEventPersistence persistence)
+        {
+            var events = Enumerable.Range(0, NumberOfEventsPerBatch)
+                .Select(i => new ThingyPingEvent(PingId.New))
+                .ToArray();
+
+            await Retry(async () =>
+            {
+                var version = await GetVersion(persistence);
+
+                var serializedEvents = from aggregateEvent in events
+                    let metadata = new Metadata
+                    {
+                        AggregateSequenceNumber = ++version
+                    }
+                    let serializedEvent = _serializer.Serialize(aggregateEvent, metadata)
+                    select serializedEvent;
+
+                var readOnlyEvents = new ReadOnlyCollection<SerializedEvent>(serializedEvents.ToList());
+
+                await persistence.CommitEventsAsync(ThingyId, readOnlyEvents, CancellationToken.None);
+            });
+        }
+
+        private static async Task<int> GetVersion(FilesEventPersistence persistence)
+        {
+            var existingEvents = await persistence.LoadCommittedEventsAsync(
+                ThingyId,
+                1,
+                CancellationToken.None);
+
+            int version = existingEvents.LastOrDefault()?.AggregateSequenceNumber ?? 0;
+            return version;
+        }
+
+        private static Task[] RunInParallel(Func<int, Task> action)
+        {
+            var tasks = Enumerable.Range(1, DegreeOfParallelism)
+                .AsParallel()
+                .WithDegreeOfParallelism(DegreeOfParallelism)
+                .Select(action);
+
+            return tasks.ToArray();
+        }
+
+        private static async Task Retry(Func<Task> action)
+        {
+            for (int retry = 0; retry < DegreeOfParallelism; retry++)
+            {
+                try
+                {
+                    await action();
+                    return;
+                }
+                catch (OptimisticConcurrencyException)
+                {
+                }
+            }
+        }
+    }
+}

--- a/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
+++ b/Source/EventFlow/EventStores/Files/FilesEventPersistence.cs
@@ -98,16 +98,20 @@ namespace EventFlow.EventStores.Files
                 ? 1
                 : int.Parse(globalPosition.Value);
 
-            var paths = Enumerable.Range(startPosition, pageSize)
-                .TakeWhile(g => _eventLog.ContainsKey(g))
-                .Select(g => _eventLog[g])
-                .ToList();
-
             var committedDomainEvents = new List<FileEventData>();
-            foreach (var path in paths)
+
+            using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                var committedDomainEvent = await LoadFileEventDataFile(path).ConfigureAwait(false);
-                committedDomainEvents.Add(committedDomainEvent);
+                var paths = Enumerable.Range(startPosition, pageSize)
+                    .TakeWhile(g => _eventLog.ContainsKey(g))
+                    .Select(g => _eventLog[g])
+                    .ToList();
+
+                foreach (var path in paths)
+                {
+                    var committedDomainEvent = await LoadFileEventDataFile(path).ConfigureAwait(false);
+                    committedDomainEvents.Add(committedDomainEvent);
+                }
             }
 
             var nextPosition = committedDomainEvents.Any()
@@ -139,14 +143,14 @@ namespace EventFlow.EventStores.Files
                     _eventLog[_globalSequenceNumber] = eventPath;
 
                     var fileEventData = new FileEventData
-                        {
-                            AggregateId = id.Value,
-                            AggregateSequenceNumber = serializedEvent.AggregateSequenceNumber,
-                            Data = serializedEvent.SerializedData,
-                            Metadata = serializedEvent.SerializedMetadata,
-                            GlobalSequenceNumber = _globalSequenceNumber,
-                        };
-            
+                    {
+                        AggregateId = id.Value,
+                        AggregateSequenceNumber = serializedEvent.AggregateSequenceNumber,
+                        Data = serializedEvent.SerializedData,
+                        Metadata = serializedEvent.SerializedMetadata,
+                        GlobalSequenceNumber = _globalSequenceNumber,
+                    };
+
                     var json = _jsonSerializer.Serialize(fileEventData, true);
 
                     if (File.Exists(eventPath))
@@ -177,7 +181,7 @@ namespace EventFlow.EventStores.Files
                         new EventStoreLog
                         {
                             GlobalSequenceNumber = _globalSequenceNumber,
-                            Log = _eventLog,
+                            Log = _eventLog
                         },
                         true);
                     await streamWriter.WriteAsync(json).ConfigureAwait(false);
@@ -209,12 +213,14 @@ namespace EventFlow.EventStores.Files
             }
         }
 
-        public Task DeleteEventsAsync(IIdentity id, CancellationToken cancellationToken)
+        public async Task DeleteEventsAsync(IIdentity id, CancellationToken cancellationToken)
         {
             _log.Verbose("Deleting entity with ID '{0}'", id);
             var path = _filesEventLocator.GetEntityPath(id);
-            Directory.Delete(path, true);
-            return Task.FromResult(0);
+            using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))
+            {
+                Directory.Delete(path, true);
+            }
         }
 
         private async Task<FileEventData> LoadFileEventDataFile(string eventPath)

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventStoresExtensions.cs
@@ -53,7 +53,7 @@ namespace EventFlow.Extensions
             return eventFlowOptions.RegisterServices(f =>
                 {
                     f.Register(_ => filesEventStoreConfiguration, Lifetime.Singleton);
-                    f.Register<IEventPersistence, FilesEventPersistence>();
+                    f.Register<IEventPersistence, FilesEventPersistence>(Lifetime.Singleton);
                     f.Register<IFilesEventLocator, FilesEventLocator>();
                 });
         }


### PR DESCRIPTION
I did some research with regard to issue #357 (File store should be thread safe):

- Added some unit tests that simulate concurrent access. Could _not_ reproduce any issues when accessing a single instance from multiple threads.
- However, added locking for public methods that didn't have it already.
- Made the `FileEventsPersistence` registration a singleton instance.

Fixes #356
Fixes #357
