### PR TITLE
Added support for unicode type names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 ### New in 0.52 (not released yet)
 
-* _Nothing yet_
+* New: Support for unicode characters in type names. This simplifies using an
+  [ubiquitous language](http://www.jamesshore.com/Agile-Book/ubiquitous_language.html)
+  in non-english domains
 
 ### New in 0.51.3155 (released 2017-10-25)
 

--- a/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
@@ -38,7 +38,7 @@ namespace EventFlow.Owin.Middlewares
     public class CommandPublishMiddleware : OwinMiddleware
     {
         private static readonly Regex CommandPath = new Regex(
-            @"/*commands/(?<name>[a-z]+)/(?<version>\d+)/{0,1}",
+            @"/*commands/(?<name>[\p{Ll}\p{Lm}\p{Lo}]+)/(?<version>\d+)/{0,1}",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly ILog _log;

--- a/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
@@ -1,0 +1,132 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2017 Rasmus Mikkelsen
+// Copyright (c) 2015-2017 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Commands;
+using EventFlow.Core;
+using EventFlow.EventStores;
+using EventFlow.Extensions;
+using EventFlow.Logs;
+using EventFlow.TestHelpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.Tests.IntegrationTests
+{
+    [Category(Categories.Integration)]
+    public class UnicodeTests
+    {
+        [Test]
+        public void UnicodeIdentities()
+        {
+            // Arrange + Act
+            var identität = Identität1.New.Value;
+            
+            // Assert
+            identität.Should().StartWith("identität1-");
+        }
+
+        [Test]
+        public void UnicodeCommands()
+        {
+            // Arrange
+            var commandDefinitions = new CommandDefinitionService(new NullLog());
+
+            // Act
+            Action action = () => commandDefinitions.Load(typeof(Cömmand));
+
+            // Assert
+            action.ShouldNotThrow();
+        }
+
+        [Test]
+        public void UnicodeEvents()
+        {
+            // Arrange
+            var eventDefinitionService = new EventDefinitionService(new NullLog());
+
+            // Act
+            Action action = () => eventDefinitionService.Load(typeof(Püng1Event));
+
+            // Assert
+            action.ShouldNotThrow();
+        }
+
+        [Test]
+        public void UnicodeIntegration()
+        {
+            var resolver = EventFlowOptions.New
+                .AddEvents(typeof(Püng1Event))
+                .AddCommands(typeof(Cömmand))
+                .AddCommandHandlers(typeof(CömmandHändler))
+                .CreateResolver();
+
+            var bus = resolver.Resolve<ICommandBus>();
+            bus.Publish(new Cömmand());
+        }
+
+        private class Identität1 : Identity<Identität1>
+        {
+            public Identität1(string value) : base(value)
+            {
+            }
+        }
+
+        private class Püng1Event : AggregateEvent<Aggregät, Identität1>
+        {
+        }
+
+        private class Aggregät : AggregateRoot<Aggregät, Identität1>
+        {
+            public Aggregät(Identität1 id) : base(id)
+            {
+            }
+
+            public void Püng()
+            {
+                this.Emit(new Püng1Event());
+            }
+
+            public void Apply(Püng1Event e) { }
+        }
+
+        private class Cömmand : Command<Aggregät, Identität1>
+        {
+            public Cömmand() : base(Identität1.New)
+            {
+            }
+        }
+
+        private class CömmandHändler : CommandHandler<Aggregät, Identität1, Cömmand>
+        {
+            public override Task ExecuteAsync(Aggregät aggregate, Cömmand command, CancellationToken cancellationToken)
+            {
+                aggregate.Püng();
+                return Task.FromResult(true);
+            }
+        }
+    }
+}

--- a/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/UnicodeTests.cs
@@ -40,6 +40,26 @@ namespace EventFlow.Tests.IntegrationTests
     public class UnicodeTests
     {
         [Test]
+        public void UpperCaseIdentityThrows()
+        {
+            // Arrange + Act
+            Action action = () => new Identität1("Identität1-00000000-0000-0000-0000-000000000000");
+
+            // Assert
+            action.ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void LowerCaseIdentityWorks()
+        {
+            // Arrange + Act
+            var id = new Identität1("identität1-00000000-0000-0000-0000-000000000000");
+
+            // Assert
+            id.GetGuid().Should().BeEmpty();
+        }
+
+        [Test]
         public void UnicodeIdentities()
         {
             // Arrange + Act

--- a/Source/EventFlow/Core/Identity.cs
+++ b/Source/EventFlow/Core/Identity.cs
@@ -44,7 +44,7 @@ namespace EventFlow.Core
             var nameReplace = new Regex("Id$");
             Name = nameReplace.Replace(typeof(T).Name, string.Empty).ToLowerInvariant();
             ValueValidation = new Regex(
-                @"^[a-z0-9]+\-(?<guid>[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})$",
+                @"^[\p{L}\p{N}]+\-(?<guid>[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})$",
                 RegexOptions.Compiled);
         }
 

--- a/Source/EventFlow/Core/Identity.cs
+++ b/Source/EventFlow/Core/Identity.cs
@@ -44,7 +44,7 @@ namespace EventFlow.Core
             var nameReplace = new Regex("Id$");
             Name = nameReplace.Replace(typeof(T).Name, string.Empty).ToLowerInvariant();
             ValueValidation = new Regex(
-                @"^[\p{L}\p{N}]+\-(?<guid>[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})$",
+                @"^[\p{Ll}\p{Lm}\p{Lo}\p{Nd}]+\-(?<guid>[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})$",
                 RegexOptions.Compiled);
         }
 

--- a/Source/EventFlow/Core/Label.cs
+++ b/Source/EventFlow/Core/Label.cs
@@ -28,7 +28,7 @@ namespace EventFlow.Core
 {
     public class Label
     {
-        private static readonly Regex NameValidator = new Regex(@"^[a-z0-9\-]{3,}$", RegexOptions.Compiled);
+        private static readonly Regex NameValidator = new Regex(@"^[\p{Ll}\p{Lm}\p{Lo}\p{Nd}\-]{3,}$", RegexOptions.Compiled);
 
         public static Label Named(string name) => new Label(name.ToLowerInvariant());
 

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
@@ -38,7 +38,7 @@ namespace EventFlow.Core.VersionedTypes
     {
         // ReSharper disable once StaticMemberInGenericType
         private static readonly Regex NameRegex = new Regex(
-            @"^(Old){0,1}(?<name>[a-zA-Z0-9]+?)(V(?<version>[0-9]+)){0,1}$",
+            @"^(Old){0,1}(?<name>[\p{L}\p{N}]+?)(V(?<version>[0-9]+)){0,1}$",
             RegexOptions.Compiled);
 
         private readonly object _syncRoot = new object();

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
@@ -38,7 +38,7 @@ namespace EventFlow.Core.VersionedTypes
     {
         // ReSharper disable once StaticMemberInGenericType
         private static readonly Regex NameRegex = new Regex(
-            @"^(Old){0,1}(?<name>[\p{L}\p{N}]+?)(V(?<version>[0-9]+)){0,1}$",
+            @"^(Old){0,1}(?<name>[\p{L}\p{Nd}]+?)(V(?<version>[0-9]+)){0,1}$",
             RegexOptions.Compiled);
 
         private readonly object _syncRoot = new object();


### PR DESCRIPTION
This is a proposal for issue #397.

Most regular expressions only check for english identifiers using `[A-Za-z0-9]`. While C# and .NET allow unicode characters in identifiers, this seems like an unnecessary restriction. This PR adds some tests with events, commands and identities with fancy names.

New expressions use [unicode general categories](https://docs.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#SupportedUnicodeGeneralCategories), like that: `[\p{L}\p{Nd}]`

## Used categories

| Category | Description |
| ---------- | ------------ |
| L | All letter characters. Includes Lu, Ll, Lt, Lm, and Lo. |
| Lu | Letter, Lowercase |
| Lt | Letter, Titlecase |
| Lm | Letter, Modifier |
| Lo | Letter, Other |
| Nd | Number, Decimal Digit |

## [C# Lexical Structure](https://github.com/dotnet/csharplang/blob/master/spec/lexical-structure.md#identifiers) excerpt

```antlr

identifier_start_character
    : letter_character
    | '_'
    ;

identifier_part_character
    : letter_character
    | decimal_digit_character
    | connecting_character
    | combining_character
    | formatting_character
    ;

letter_character
    : '<A Unicode character of classes Lu, Ll, Lt, Lm, Lo, or Nl>'
    | '<A unicode_escape_sequence representing a character of classes Lu, Ll, Lt, Lm, Lo, or Nl>'
    ;

decimal_digit_character
    : '<A Unicode character of the class Nd>'
    | '<A unicode_escape_sequence representing a character of the class Nd>'
    ;
```
