### PR TITLE
Fixed #399: Made static Sha256 instance transient

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
   event, it may now return `Task.FromResult(null)` in order to short-circuit
   the dispatching process. This might be useful in cases where some instances 
   of an event belong to a saga process while others don't
+* Fixed: `StringExtensions.ToSha256()` can now be safely used from
+  concurrent threads.
 
 ### New in 0.50.3124 (released 2017-10-21)
 

--- a/Source/EventFlow/Extensions/StringExtensions.cs
+++ b/Source/EventFlow/Extensions/StringExtensions.cs
@@ -31,7 +31,6 @@ namespace EventFlow.Extensions
     public static class StringExtensions
     {
         private static readonly Regex RegexToSlug = new Regex("(?<=.)([A-Z])", RegexOptions.Compiled);
-        private static readonly SHA256 Sha256Managed = SHA256.Create();
 
         public static string ToSlug(this string str)
         {
@@ -41,10 +40,13 @@ namespace EventFlow.Extensions
         public static string ToSha256(this string str)
         {
             var bytes = Encoding.UTF8.GetBytes(str);
-            var hash = Sha256Managed.ComputeHash(bytes);
-            return hash
-                .Aggregate(new StringBuilder(), (sb, b) => sb.Append($"{b:x2}"))
-                .ToString();
+            using (var sha256 = SHA256.Create())
+            {
+                var hash = sha256.ComputeHash(bytes);
+                return hash
+                    .Aggregate(new StringBuilder(), (sb, b) => sb.Append($"{b:x2}"))
+                    .ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
StringExtensions.ToSha256() could not be used by concurrent threads because a static instance was involved. Fixed this issue by making it transient and disposing it.