### PR TITLE
WIP: State Machine

### DIFF
--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/IState.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/IState.cs
@@ -1,0 +1,6 @@
+namespace EventFlow.Tests.Exploration.StateMachine.Framework
+{
+    public interface IState
+    {
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/IStateMachineDefinition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/IStateMachineDefinition.cs
@@ -1,0 +1,12 @@
+using System;
+using EventFlow.Tests.Exploration.StateMachine.Framework.Transitions;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework
+{
+    public interface IStateMachineDefinition
+    {
+        Type InitialStateType { get; }
+
+        ITransition GetTransition(TransitionKey key);
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/ITransition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/ITransition.cs
@@ -1,0 +1,14 @@
+using EventFlow.Aggregates;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework
+{
+    public interface ITransition
+    {
+        IState Execute(IState currentState, IAggregateEvent signal);
+    }
+
+    public interface ITransition<in TState, in TSignal>
+    {
+        IState Execute(TState currentState, TSignal signal);
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/StateMachine.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/StateMachine.cs
@@ -1,0 +1,76 @@
+using System;
+using EventFlow.Aggregates;
+using EventFlow.Core;
+using EventFlow.Tests.Exploration.StateMachine.Framework.Transitions;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework
+{
+    public abstract class StateMachine<TStateMachine, TIdentity> : AggregateRoot<TStateMachine, TIdentity>
+        where TIdentity : IIdentity
+        where TStateMachine : StateMachine<TStateMachine, TIdentity>
+    {
+        // ReSharper disable StaticMemberInGenericType
+        private static readonly object DefinitionLock = new object();
+
+        private static IStateMachineDefinition _definition;
+        // ReSharper enable StaticMemberInGenericType
+
+        protected StateMachine(TIdentity id) : base(id)
+        {
+            var definition = GetDefinition();
+            CurrentState = (IState) Activator.CreateInstance(definition.InitialStateType);
+        }
+
+        protected IState CurrentState { get; private set; }
+
+        protected override void Emit<TEvent>(TEvent aggregateEvent, IMetadata metadata = null)
+        {
+            InvokeTransition(aggregateEvent);
+            base.Emit(aggregateEvent, metadata);
+        }
+
+        protected override void ApplyEvent(IAggregateEvent<TStateMachine, TIdentity> aggregateEvent)
+        {
+            CurrentState = InvokeTransition(aggregateEvent);
+            Version++;
+        }
+
+        protected abstract IStateMachineDefinition Define(StateMachineBuilder<TStateMachine, TIdentity> builder);
+
+        private IState InvokeTransition(IAggregateEvent aggregateEvent)
+        {
+            var definition = GetDefinition();
+            var key = new TransitionKey(CurrentState.GetType(), aggregateEvent.GetType());
+
+            var transition = definition.GetTransition(key);
+            if (transition == null)
+                throw new InvalidOperationException("Signal not valid in this state.");
+
+            var nextState = transition.Execute(CurrentState, aggregateEvent);
+            if (nextState == null)
+                throw new InvalidOperationException("Transition did not result in a valid state.");
+
+            return nextState;
+        }
+
+        private IStateMachineDefinition GetDefinition()
+        {
+            lock (DefinitionLock)
+            {
+                if (_definition != null)
+                    return _definition;
+            }
+
+            var definition = Define(new StateMachineBuilder<TStateMachine, TIdentity>());
+
+            lock (DefinitionLock)
+            {
+                if (_definition != null)
+                    return _definition;
+
+                _definition = definition;
+                return _definition;
+            }
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/StateMachineBuilder.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/StateMachineBuilder.cs
@@ -1,0 +1,129 @@
+using System;
+using EventFlow.Aggregates;
+using EventFlow.Core;
+using EventFlow.Tests.Exploration.StateMachine.Framework.Transitions;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework
+{
+    public class StateMachineBuilder<TStateMachine, TIdentity> where TStateMachine : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+    {
+        private StateMachineDefinition _definition;
+
+        public IInSyntax StartWith<TState>() where TState : IState, new()
+        {
+            _definition = new StateMachineDefinition(typeof(TState));
+            return new InBuilder(this);
+        }
+
+        private abstract class SyntaxBase
+        {
+            protected readonly StateMachineBuilder<TStateMachine, TIdentity> Root;
+
+            protected SyntaxBase(StateMachineBuilder<TStateMachine, TIdentity> root)
+            {
+                Root = root;
+            }
+        }
+
+        private class InBuilder : SyntaxBase, IInSyntax
+        {
+            public InBuilder(StateMachineBuilder<TStateMachine, TIdentity> root) : base(root)
+            {
+            }
+
+            public IWhenSyntax<TState> In<TState>() where TState : IState
+            {
+                return new ContinueBuilder<TState>(Root);
+            }
+        }
+
+        private class ContinueBuilder<TState> : SyntaxBase,
+            IInBuildWhenSyntax<TState> where TState : IState
+        {
+            public ContinueBuilder(StateMachineBuilder<TStateMachine, TIdentity> root) : base(root)
+            {
+            }
+
+            public IUseSyntax<TState, TSignal> When<TSignal>()
+                where TSignal : IAggregateEvent<TStateMachine, TIdentity>
+            {
+                return new UseBuilder<TState, TSignal>(Root);
+            }
+
+            public IStateMachineDefinition Build()
+            {
+                return Root._definition;
+            }
+
+            public IWhenSyntax<T> In<T>() where T : IState
+            {
+                return new ContinueBuilder<T>(Root);
+            }
+        }
+
+        private class UseBuilder<TState, TSignal> : SyntaxBase, IUseSyntax<TState, TSignal>
+            where TState : IState
+            where TSignal : IAggregateEvent<TStateMachine, TIdentity>
+        {
+            public UseBuilder(StateMachineBuilder<TStateMachine, TIdentity> root) : base(root)
+            {
+            }
+
+            public IInBuildWhenSyntax<TState> Use<TTransition>()
+                where TTransition : ITransition<TState, TSignal>, new()
+            {
+                Add(new GenericTransitionAdapter<TState, TSignal>(() => new TTransition()));
+                return Continue();
+            }
+
+            public IInBuildWhenSyntax<TState> Use(Func<TState, TSignal, IState> transition)
+            {
+                Add(new FuncTransition<TState, TSignal>(transition));
+                return Continue();
+            }
+
+            public IInBuildWhenSyntax<TState> Ignore()
+            {
+                Add(new IgnoreTransition());
+                return Continue();
+            }
+
+            private void Add(ITransition transition)
+            {
+                Root._definition.Add<TState, TSignal>(transition);
+            }
+
+            private ContinueBuilder<TState> Continue()
+            {
+                return new ContinueBuilder<TState>(Root);
+            }
+        }
+
+        public interface IInSyntax
+        {
+            IWhenSyntax<TState> In<TState>() where TState : IState;
+        }
+
+        public interface IInBuildWhenSyntax<TState> : IInSyntax, IWhenSyntax<TState>
+            where TState : IState
+        {
+            IStateMachineDefinition Build();
+        }
+
+        public interface IWhenSyntax<TState> where TState : IState
+        {
+            IUseSyntax<TState, TSignal> When<TSignal>() where TSignal : IAggregateEvent<TStateMachine, TIdentity>;
+        }
+
+        public interface IUseSyntax<TState, out TSignal>
+            where TState : IState
+            where TSignal : IAggregateEvent<TStateMachine, TIdentity>
+        {
+            IInBuildWhenSyntax<TState> Use<TTransition>()
+                where TTransition : ITransition<TState, TSignal>, new();
+
+            IInBuildWhenSyntax<TState> Ignore();
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/StateMachineDefinition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/StateMachineDefinition.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using EventFlow.Tests.Exploration.StateMachine.Framework.Transitions;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework
+{
+    internal class StateMachineDefinition : IStateMachineDefinition
+    {
+        private readonly Dictionary<TransitionKey, ITransition> _transitions
+            = new Dictionary<TransitionKey, ITransition>();
+
+        public StateMachineDefinition(Type initialStateType)
+        {
+            InitialStateType = initialStateType;
+        }
+
+        public Type InitialStateType { get; }
+
+        public ITransition GetTransition(TransitionKey key)
+        {
+            _transitions.TryGetValue(key, out var value);
+            return value;
+        }
+
+        public void Add<TState, TSignal>(ITransition transition)
+        {
+            var key = new TransitionKey(typeof(TState), typeof(TSignal));
+            _transitions.Add(key, transition);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/FuncTransition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/FuncTransition.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using EventFlow.Aggregates;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework.Transitions
+{
+    internal class FuncTransition<TState, TSignal> : ITransition
+    {
+        private readonly Func<TState, TSignal, IState> _func;
+
+        public FuncTransition(Func<TState, TSignal, IState> func)
+        {
+            _func = func;
+        }
+
+        public IState Execute(IState currentState, IAggregateEvent signal)
+        {
+            return _func((TState) currentState, (TSignal) signal);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/GenericTransitionAdapter.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/GenericTransitionAdapter.cs
@@ -1,0 +1,21 @@
+using System;
+using EventFlow.Aggregates;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework.Transitions
+{
+    public class GenericTransitionAdapter<TState, TSignal> : ITransition
+    {
+        private readonly Func<ITransition<TState, TSignal>> _factory;
+
+        public GenericTransitionAdapter(Func<ITransition<TState, TSignal>> factory)
+        {
+            _factory = factory;
+        }
+
+        public IState Execute(IState currentState, IAggregateEvent signal)
+        {
+            var transition = _factory();
+            return transition.Execute((TState) currentState, (TSignal) signal);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/IgnoreTransition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/IgnoreTransition.cs
@@ -1,0 +1,12 @@
+﻿using EventFlow.Aggregates;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework.Transitions
+{
+    internal class IgnoreTransition : ITransition
+    {
+        public IState Execute(IState currentState, IAggregateEvent signal)
+        {
+            return currentState;
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/TransitionKey.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Framework/Transitions/TransitionKey.cs
@@ -1,0 +1,22 @@
+using System;
+using EventFlow.Extensions;
+using EventFlow.ValueObjects;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Framework.Transitions
+{
+    public class TransitionKey : SingleValueObject<string>
+    {
+        public TransitionKey(Type stateType, Type signalType)
+            : base(CreateValue(stateType, signalType))
+        {
+        }
+
+        private static string CreateValue(Type stateType, Type signalType)
+        {
+            if (stateType == null) throw new ArgumentNullException(nameof(stateType));
+            if (signalType == null) throw new ArgumentNullException(nameof(signalType));
+
+            return $"{stateType.PrettyPrint()}-{signalType.PrettyPrint()}";
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/InsertCoin.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/InsertCoin.cs
@@ -1,0 +1,14 @@
+using EventFlow.Commands;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Commands
+{
+    public class InsertCoin : Command<VendingMachine, VendingMachineId>
+    {
+        public InsertCoin(VendingMachineId aggregateId, int value) : base(aggregateId)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/InsertCoinHandler.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/InsertCoinHandler.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Commands;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Commands
+{
+    public class InsertCoinHandler : CommandHandler<VendingMachine, VendingMachineId, InsertCoin>
+    {
+        public override Task ExecuteAsync(VendingMachine aggregate, InsertCoin command,
+            CancellationToken cancellationToken)
+        {
+            aggregate.InsertCoin(command.Value);
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/Select.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/Select.cs
@@ -1,0 +1,14 @@
+using EventFlow.Commands;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Commands
+{
+    public class Select : Command<VendingMachine, VendingMachineId>
+    {
+        public Select(VendingMachineId aggregateId, Selection selection) : base(aggregateId)
+        {
+            Selection = selection;
+        }
+
+        public Selection Selection { get; }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/SelectHandler.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Commands/SelectHandler.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Commands;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Commands
+{
+    public class SelectHandler : CommandHandler<VendingMachine, VendingMachineId, Select>
+    {
+        private static readonly Dictionary<Selection, int> Prices
+            = new Dictionary<Selection, int>
+            {
+                {Selection.Chocolate, 5},
+                {Selection.Ice, 6},
+                {Selection.Nuts, 7}
+            };
+
+        public override Task ExecuteAsync(VendingMachine aggregate, Select command, CancellationToken cancellationToken)
+        {
+            var selection = command.Selection;
+            var price = Prices[selection];
+            aggregate.Select(selection, price);
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Events/CoinInserted.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Events/CoinInserted.cs
@@ -1,0 +1,14 @@
+using EventFlow.Aggregates;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Events
+{
+    public class CoinInserted : AggregateEvent<VendingMachine, VendingMachineId>
+    {
+        public CoinInserted(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Events/Selected.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Events/Selected.cs
@@ -1,0 +1,17 @@
+using EventFlow.Aggregates;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Events
+{
+    public class Selected : AggregateEvent<VendingMachine, VendingMachineId>
+    {
+        public Selected(Selection selection, int price)
+        {
+            Selection = selection;
+            Price = price;
+        }
+
+        public Selection Selection { get; }
+
+        public int Price { get; }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Selection.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Selection.cs
@@ -1,0 +1,9 @@
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario
+{
+    public enum Selection
+    {
+        Ice,
+        Nuts,
+        Chocolate
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/States/SelectedState.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/States/SelectedState.cs
@@ -1,0 +1,17 @@
+using EventFlow.Tests.Exploration.StateMachine.Framework;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.States
+{
+    public class SelectedState : IState
+    {
+        public SelectedState(Selection selection, int change)
+        {
+            Selection = selection;
+            Change = change;
+        }
+
+        public Selection Selection { get; }
+
+        public int Change { get; }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/States/WaitingForCoinsState.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/States/WaitingForCoinsState.cs
@@ -1,0 +1,23 @@
+using EventFlow.Tests.Exploration.StateMachine.Framework;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.States
+{
+    public class WaitingForCoinsState : IState
+    {
+        public WaitingForCoinsState()
+        {
+        }
+
+        public WaitingForCoinsState(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+
+        public IState Add(int value)
+        {
+            return new WaitingForCoinsState(value + Value);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Transitions/AddCoinTransition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Transitions/AddCoinTransition.cs
@@ -1,0 +1,14 @@
+using EventFlow.Tests.Exploration.StateMachine.Framework;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.Events;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.States;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Transitions
+{
+    public class AddCoinTransition : ITransition<WaitingForCoinsState, CoinInserted>
+    {
+        public IState Execute(WaitingForCoinsState currentState, CoinInserted signal)
+        {
+            return currentState.Add(signal.Value);
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Transitions/CheckEnoughCoinsTransition.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/Transitions/CheckEnoughCoinsTransition.cs
@@ -1,0 +1,18 @@
+using EventFlow.Tests.Exploration.StateMachine.Framework;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.Events;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.States;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario.Transitions
+{
+    public class CheckEnoughCoinsTransition : ITransition<WaitingForCoinsState, Selected>
+    {
+        public IState Execute(WaitingForCoinsState currentState, Selected signal)
+        {
+            var change = currentState.Value - signal.Price;
+            if (change >= 0)
+                return new SelectedState(signal.Selection, change);
+
+            return currentState;
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/VendingMachine.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/VendingMachine.cs
@@ -1,0 +1,40 @@
+using EventFlow.Tests.Exploration.StateMachine.Framework;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.Events;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.States;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.Transitions;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario
+{
+    public class VendingMachine : StateMachine<VendingMachine, VendingMachineId>
+    {
+        public VendingMachine(VendingMachineId id) : base(id)
+        {
+        }
+
+        protected override IStateMachineDefinition Define(StateMachineBuilder<VendingMachine, VendingMachineId> builder)
+        {
+            return builder
+                .StartWith<WaitingForCoinsState>()
+
+                .In<WaitingForCoinsState>()
+                .When<CoinInserted>().Use<AddCoinTransition>()
+                .When<Selected>().Use<CheckEnoughCoinsTransition>()
+
+                .In<SelectedState>()
+                .When<CoinInserted>().Ignore()
+                .When<Selected>().Ignore()
+
+                .Build();
+        }
+
+        public void InsertCoin(int value)
+        {
+            Emit(new CoinInserted(value));
+        }
+
+        public void Select(Selection selection, int price)
+        {
+            Emit(new Selected(selection, price));
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/VendingMachineId.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/Scenario/VendingMachineId.cs
@@ -1,0 +1,11 @@
+using EventFlow.Core;
+
+namespace EventFlow.Tests.Exploration.StateMachine.Scenario
+{
+    public class VendingMachineId : Identity<VendingMachineId>
+    {
+        public VendingMachineId(string value) : base(value)
+        {
+        }
+    }
+}

--- a/Source/EventFlow.Tests/Exploration/StateMachine/StateMachineExplorationTests.cs
+++ b/Source/EventFlow.Tests/Exploration/StateMachine/StateMachineExplorationTests.cs
@@ -1,0 +1,30 @@
+﻿using EventFlow.Extensions;
+using EventFlow.Tests.Exploration.StateMachine.Scenario;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.Commands;
+using EventFlow.Tests.Exploration.StateMachine.Scenario.Events;
+using NUnit.Framework;
+
+namespace EventFlow.Tests.Exploration.StateMachine
+{
+    public class StateMachineExplorationTests
+    {
+        [Test]
+        public void Test()
+        {
+            var resolver =
+                EventFlowOptions.New
+                    .AddEvents(typeof(CoinInserted), typeof(Selected))
+                    .AddCommands(typeof(InsertCoin), typeof(Select))
+                    .AddCommandHandlers(typeof(InsertCoinHandler), typeof(SelectHandler))
+                    .CreateResolver();
+
+            var bus = resolver.Resolve<ICommandBus>();
+            var id = VendingMachineId.New;
+
+            bus.Publish(new InsertCoin(id, 2));
+            bus.Publish(new Select(id, Selection.Chocolate));
+            bus.Publish(new InsertCoin(id, 5));
+            bus.Publish(new Select(id, Selection.Ice));
+        }
+    }
+}


### PR DESCRIPTION
This is the very first conceptual draft for a **state machine**, requesting for comments.

## Why?

For aggregates that use more than a few events and constantly need to check on some enum value if they are in the right, well, state.

## Definition syntax

```csharp
return builder
    .StartWith<WaitingForCoinsState>()
    .In<WaitingForCoinsState>()
        .When<CoinInserted>().Use<AddCoinTransition>()
        .When<Selected>().Use<CheckEnoughCoinsTransition>()
    .In<SelectedState>()
        .When<CoinInserted>().Ignore()
        .When<Selected>().Use((state, signal) => state.With(signal.Selection))
    .Build();
```
## Transition syntax

```csharp
public class CheckEnoughCoinsTransition : ITransition<WaitingForCoinsState, Selected>
{
    public IState Execute(WaitingForCoinsState currentState, Selected signal)
    {
        var change = currentState.Value - signal.Price;
        if (change >= 0)
            return new SelectedState(signal.Selection, change);

        return currentState;
    }
}
```

## Usage

```csharp
public void InsertCoin(int value)
{
    Emit(new CoinInserted(value));
}

public void Select(Selection selection, int price)
{
    Emit(new Selected(selection, price));
}
```

Emitting an event will look for a transition that matches current state and event type. If there is no transition, Emit fails. If executing the transition returns null or throws an exception, Emit also fails. If emit doesn't fail, it will continue as usual, finally applying the event. Applying does the same thing as above, but this time it will replace the current state with the new state returned from the transition.

## Issues

1. Emitting events before inspecting the state goes against how EventFlow works otherwise:
    - Events should only be created if something is allowed to happen, i.e. if there is a transition and the transition doesn't throw.
    - Should events and signals be different things? If so, how would a transition work?

        ``` csharp
        var transition = GetTransition(signal, CurrentState);
        var event = transition.Handle(signal, CurrentState); // Check inputs and current state
        if (event == null) throw;
        CurrentState = transition.Apply(event, CurrentState); // Execute transition
        ```

    - Could we then use commands as signals, and handle them implicitly? Dependency injection in transitions would make them comparable to command handlers. Maybe we don't need both.
1. Can we somehow enforce that states are immutable? Transitions should always return new instances instead of mutating the current state.
1. Should the state machine work at the aggregate level (which would need multiple implementations for `AggregateRoot` and `AggregateSaga`) or at the AggregateState level, pluggable into aggregates and sagas? How would that work?
