### PR TITLE
Upgrade to net standard 2.0

### DIFF
--- a/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
+++ b/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
@@ -21,7 +21,7 @@
     <PackageReleaseNotes>UPDATED BY BUILD</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.5.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventFlow\EventFlow.csproj" />

--- a/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
+++ b/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />  
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
+++ b/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
+++ b/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
@@ -24,7 +24,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NEST" Version="5.3.1" />
+    <PackageReference Include="NEST" Version="5.5.0" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />    
   </ItemGroup>
   <ItemGroup>

--- a/Source/EventFlow.Hangfire.Tests/EventFlow.Hangfire.Tests.csproj
+++ b/Source/EventFlow.Hangfire.Tests/EventFlow.Hangfire.Tests.csproj
@@ -9,7 +9,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hangfire.SqlServer" Version="1.6.15" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.6.17" />
     <PackageReference Include="Microsoft.Owin" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="3.1.0" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="3.1.0" />

--- a/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
+++ b/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
@@ -24,7 +24,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.6.15" />
+    <PackageReference Include="Hangfire.Core" Version="1.6.17" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />    
   </ItemGroup>
   <ItemGroup>

--- a/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
+++ b/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
+++ b/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -30,5 +30,9 @@
     <EmbeddedResource Include="EventStores\Scripts\0001 - Create table EventFlow.sql" />
     <EmbeddedResource Include="EventStores\Scripts\0002 - Create eventdatamodel_list_type.sql" />
     <EmbeddedResource Include="SnapshotStores\Scripts\0001 - Create EventFlowSnapshots.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/Source/EventFlow.RabbitMQ/EventFlow.RabbitMQ.csproj
+++ b/Source/EventFlow.RabbitMQ/EventFlow.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -25,13 +25,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.2" />
-    <PackageReference Condition="'$(TargetFramework)' == 'net451'" Include="dbup" Version="3.3.5" />
-    <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.6'" Include="System.ComponentModel.Annotations" Version="4.3.0" />
+    <PackageReference Include="dbup" Version="4.0.0-beta0002" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventFlow\EventFlow.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 </Project>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -23,9 +23,17 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <PackageReference Include="dbup" Version="3.3.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="dbup" Version="4.0.0-beta0002" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.2" />
-    <PackageReference Include="dbup" Version="4.0.0-beta0002" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
+++ b/Source/EventFlow.Sql/Integrations/DbUpUpgradeLog.cs
@@ -21,7 +21,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if NET451
 
 using DbUp.Engine.Output;
 using EventFlow.Logs;
@@ -53,5 +52,3 @@ namespace EventFlow.Sql.Integrations
         }
     }
 }
-
-#endif

--- a/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
+++ b/Source/EventFlow.Sql/Migrations/SqlDatabaseMigrator.cs
@@ -21,8 +21,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if NET451
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,5 +103,3 @@ namespace EventFlow.Sql.Migrations
         }
     }
 }
-
-#endif

--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
@rasmus it was only possible to target `netstandard 2.0` in the `MsSql` & `Sql `projects by using the latest, beta, version of `DbUp`. I can't see any other projects using pre-release nuget packages so I don't know if you'll be OK with that..?

Whilst I was there I upgraded the projects targeting `netstandard 1.6` to `2.0`, too. There are no code changes here, just `csproj `and removal of `#if` directives.