### PR TITLE
Remove single event version attribute limit

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ### New in 0.53 (not released yet)
 
-* _Nothing yet_
+* New: Allow events to have multiple `EventVersion` attributes
 
 ### New in 0.52.3178 (released 2017-11-02)
 

--- a/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
@@ -29,7 +29,6 @@ using EventFlow.TestHelpers;
 using FluentAssertions;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
-using Test = NUnit.Framework.Internal.Test;
 
 namespace EventFlow.Tests.UnitTests.Core.VersionedTypes
 {
@@ -224,7 +223,7 @@ namespace EventFlow.Tests.UnitTests.Core.VersionedTypes
             Assert.DoesNotThrow(() => Sut.Load(null));
         }
 
-        private IReadOnlyCollection<Type> Arrange_LoadAllTestTypes()
+        protected IReadOnlyCollection<Type> Arrange_LoadAllTestTypes()
         {
             var types = GetTestCases()
                 .Select(t => t.Type)

--- a/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/VersionedTypes/VersionedTypeDefinitionServiceTestSuite.cs
@@ -29,6 +29,7 @@ using EventFlow.TestHelpers;
 using FluentAssertions;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using Test = NUnit.Framework.Internal.Test;
 
 namespace EventFlow.Tests.UnitTests.Core.VersionedTypes
 {
@@ -84,12 +85,14 @@ namespace EventFlow.Tests.UnitTests.Core.VersionedTypes
             Arrange_LoadAllTestTypes();
 
             // Act
-            var eventDefinition = Sut.GetDefinition(testCase.Type);
+            var eventDefinitions = Sut.GetDefinitions(testCase.Type);
 
             // Assert
-            eventDefinition.Name.Should().Be(testCase.Name);
-            eventDefinition.Version.Should().Be(testCase.Version);
-            eventDefinition.Type.Should().Be(testCase.Type);
+            var hasIt = eventDefinitions.SingleOrDefault(e =>
+                e.Name == testCase.Name &&
+                e.Version == testCase.Version &&
+                e.Type == testCase.Type);
+            hasIt.Should().NotBeNull();
         }
 
         [Test]
@@ -199,7 +202,9 @@ namespace EventFlow.Tests.UnitTests.Core.VersionedTypes
             var expectedTypes = Arrange_LoadAllTestTypes();
 
             // Act
-            var result = Sut.GetAllDefinitions().Select(d => d.Type).ToList();
+            var result = Sut.GetAllDefinitions().Select(d => d.Type)
+                .Distinct()
+                .ToList();
 
             // Assert
             result.ShouldAllBeEquivalentTo(expectedTypes);
@@ -221,7 +226,10 @@ namespace EventFlow.Tests.UnitTests.Core.VersionedTypes
 
         private IReadOnlyCollection<Type> Arrange_LoadAllTestTypes()
         {
-            var types = GetTestCases().Select(t => t.Type).ToList();
+            var types = GetTestCases()
+                .Select(t => t.Type)
+                .Distinct()
+                .ToList();
             Sut.Load(types);
             return types;
         }

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using EventFlow.Aggregates;
 using EventFlow.Core;
@@ -34,6 +35,17 @@ namespace EventFlow.Tests.UnitTests.EventStores
     [Category(Categories.Unit)]
     public class EventDefinitionServiceTests : VersionedTypeDefinitionServiceTestSuite<EventDefinitionService, IAggregateEvent, EventVersionAttribute, EventDefinition>
     {
+        [Test]
+        public void GetDefinition_OnEventWithMultipleDefinitions_ThrowsException()
+        {
+            // Arrange
+            Arrange_LoadAllTestTypes();
+
+            // Act + Assert
+            Assert.Throws<InvalidOperationException>(
+                () => Sut.GetDefinition(typeof(MultiNamesEvent)));
+        }
+
         [EventVersion("Fancy", 42)]
         public class TestEventWithLongName : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
         

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -36,6 +36,11 @@ namespace EventFlow.Tests.UnitTests.EventStores
     {
         [EventVersion("Fancy", 42)]
         public class TestEventWithLongName : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
+        
+        [EventVersion("multi-names-event", 1)]
+        [EventVersion("MultiNamesEvent", 1)]
+        [EventVersion("MultiNamesEvent", 2)]
+        public class MultiNamesEvent : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
 
         public class TestEvent : AggregateEvent<IAggregateRoot<IIdentity>, IIdentity> { }
 
@@ -76,6 +81,26 @@ namespace EventFlow.Tests.UnitTests.EventStores
                     Name = "The5ThEvent",
                     Type = typeof(OldThe5ThEventV4),
                     Version = 4,
+                };
+            
+            // Multiple names to same events
+            yield return new VersionTypeTestCase
+                {
+                    Name = "multi-names-event",
+                    Type = typeof(MultiNamesEvent),
+                    Version = 1,
+                };
+            yield return new VersionTypeTestCase
+                {
+                    Name = "MultiNamesEvent",
+                    Type = typeof(MultiNamesEvent),
+                    Version = 1,
+                };
+            yield return new VersionTypeTestCase
+                {
+                    Name = "MultiNamesEvent",
+                    Type = typeof(MultiNamesEvent),
+                    Version = 2,
                 };
         }
     }

--- a/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/EventDefinitionServiceTests.cs
@@ -23,11 +23,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EventFlow.Aggregates;
 using EventFlow.Core;
 using EventFlow.EventStores;
 using EventFlow.TestHelpers;
 using EventFlow.Tests.UnitTests.Core.VersionedTypes;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace EventFlow.Tests.UnitTests.EventStores
@@ -44,6 +46,22 @@ namespace EventFlow.Tests.UnitTests.EventStores
             // Act + Assert
             Assert.Throws<InvalidOperationException>(
                 () => Sut.GetDefinition(typeof(MultiNamesEvent)));
+        }
+
+        [Test]
+        public void GetDefinitions_OnEventWithMultipleDefinitions_ReturnsThemAll()
+        {
+            // Arrange
+            Sut.Load(typeof(MultiNamesEvent));
+
+            // Act
+            var eventDefinitions = Sut.GetDefinitions(typeof(MultiNamesEvent));
+
+            // Assert
+            eventDefinitions.Should().HaveCount(3);
+            eventDefinitions
+                .Select(d => $"{d.Name}-V{d.Version}")
+                .ShouldAllBeEquivalentTo(new []{"multi-names-event-V1", "MultiNamesEvent-V1", "MultiNamesEvent-V2"});
         }
 
         [EventVersion("Fancy", 42)]

--- a/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/IVersionedTypeDefinitionService.cs
@@ -36,7 +36,9 @@ namespace EventFlow.Core.VersionedTypes
         IEnumerable<TDefinition> GetAllDefinitions();
         TDefinition GetDefinition(string name, int version);
         TDefinition GetDefinition(Type type);
+        IReadOnlyCollection<TDefinition> GetDefinitions(Type type);
         bool TryGetDefinition(Type type, out TDefinition definition);
+        bool TryGetDefinitions(Type type, out IReadOnlyCollection<TDefinition> definitions);
         void Load(params Type[] types);
     }
 }

--- a/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
+++ b/Source/EventFlow/Core/VersionedTypes/VersionedTypeDefinitionService.cs
@@ -43,7 +43,7 @@ namespace EventFlow.Core.VersionedTypes
 
         private readonly object _syncRoot = new object();
         private readonly ILog _log;
-        private readonly ConcurrentDictionary<Type, TDefinition> _definitionsByType = new ConcurrentDictionary<Type, TDefinition>();
+        private readonly ConcurrentDictionary<Type, List<TDefinition>> _definitionsByType = new ConcurrentDictionary<Type, List<TDefinition>>();
         private readonly ConcurrentDictionary<string, Dictionary<int, TDefinition>> _definitionByNameAndVersion = new ConcurrentDictionary<string, Dictionary<int, TDefinition>>(); 
 
         protected VersionedTypeDefinitionService(
@@ -77,7 +77,7 @@ namespace EventFlow.Core.VersionedTypes
                 var definitions = types
                     .Distinct()
                     .Where(t => !_definitionsByType.ContainsKey(t))
-                    .Select(CreateDefinition)
+                    .SelectMany(CreateDefinitions)
                     .ToList();
                 if (!definitions.Any())
                 {
@@ -100,10 +100,12 @@ namespace EventFlow.Core.VersionedTypes
 
                 foreach (var definition in definitions)
                 {
-                    _definitionsByType.TryAdd(definition.Type, definition);
+                    var typeDefinitions = _definitionsByType.GetOrAdd(
+                        definition.Type,
+                        _ => new List<TDefinition>());
+                    typeDefinitions.Add(definition);
 
-                    Dictionary<int, TDefinition> versions;
-                    if (!_definitionByNameAndVersion.TryGetValue(definition.Name, out versions))
+                    if (!_definitionByNameAndVersion.TryGetValue(definition.Name, out var versions))
                     {
                         versions = new Dictionary<int, TDefinition>();
                         _definitionByNameAndVersion.TryAdd(definition.Name, versions);
@@ -125,8 +127,7 @@ namespace EventFlow.Core.VersionedTypes
 
         public IEnumerable<TDefinition> GetDefinitions(string name)
         {
-            Dictionary<int, TDefinition> versions;
-            return _definitionByNameAndVersion.TryGetValue(name, out versions)
+            return _definitionByNameAndVersion.TryGetValue(name, out var versions)
                 ? versions.Values.OrderBy(d => d.Version)
                 : Enumerable.Empty<TDefinition>();
         }
@@ -138,8 +139,7 @@ namespace EventFlow.Core.VersionedTypes
 
         public bool TryGetDefinition(string name, int version, out TDefinition definition)
         {
-            Dictionary<int, TDefinition> versions;
-            if (_definitionByNameAndVersion.TryGetValue(name, out versions))
+            if (_definitionByNameAndVersion.TryGetValue(name, out var versions))
             {
                 return versions.TryGetValue(version, out definition);
             }
@@ -151,8 +151,7 @@ namespace EventFlow.Core.VersionedTypes
 
         public TDefinition GetDefinition(string name, int version)
         {
-            TDefinition definition;
-            if (!TryGetDefinition(name, version, out definition))
+            if (!TryGetDefinition(name, version, out var definition))
             {
                 throw new ArgumentException($"No versioned type definition for '{name}' with version {version} in '{GetType().PrettyPrint()}'");
             }
@@ -162,10 +161,7 @@ namespace EventFlow.Core.VersionedTypes
 
         public TDefinition GetDefinition(Type type)
         {
-            if (type == null) throw new ArgumentNullException(nameof(type));
-
-            TDefinition definition;
-            if (!_definitionsByType.TryGetValue(type, out definition))
+            if (!TryGetDefinition(type, out var definition))
             {
                 throw new ArgumentException($"No definition for type '{type.PrettyPrint()}', have you remembered to load it during EventFlow initialization");
             }
@@ -173,33 +169,60 @@ namespace EventFlow.Core.VersionedTypes
             return definition;
         }
 
+        public IReadOnlyCollection<TDefinition> GetDefinitions(Type type)
+        {
+            if (!TryGetDefinitions(type, out var definitions))
+            {
+                throw new ArgumentException($"No definition for type '{type.PrettyPrint()}', have you remembered to load it during EventFlow initialization");
+            }
+
+            return definitions;
+        }
+
         public bool TryGetDefinition(Type type, out TDefinition definition)
+        {
+            if (!TryGetDefinitions(type, out var definitions))
+            {
+                definition = default(TDefinition);
+                return false;
+            }
+
+            if (definitions.Count > 1)
+            {
+                throw new InvalidOperationException($"Type '{type.PrettyPrint()}' has multiple definitions: {string.Join(", ", definitions.Select(d => d.ToString()))}");
+            }
+
+            definition = definitions.Single();
+            return true;
+        }
+
+        public bool TryGetDefinitions(Type type, out IReadOnlyCollection<TDefinition> definitions)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            return _definitionsByType.TryGetValue(type, out definition);
-        }
-
-        private TDefinition CreateDefinition(Type type)
-        {
-            var definition = CreateDefinitions(type).FirstOrDefault(d => d != null);
-            if (definition == null)
+            if (!_definitionsByType.TryGetValue(type, out var list))
             {
-                throw new ArgumentException(
-                    $"Could not create a versioned type definition for type '{type.PrettyPrint()}' in '{GetType().PrettyPrint()}'",
-                    nameof(type));
+                definitions = default(IReadOnlyCollection<TDefinition>);
+                return false;
             }
 
-            _log.Verbose(() => $"{GetType().PrettyPrint()}: Added versioned type definition '{definition}'");
-
-            return definition;
+            definitions = list;
+            return true;
         }
 
         protected abstract TDefinition CreateDefinition(int version, Type type, string name);
 
         private IEnumerable<TDefinition> CreateDefinitions(Type versionedType)
         {
-            yield return CreateDefinitionFromAttribute(versionedType);
+            var hasAttributeDefinition = false;
+            foreach (var definitionFromAttribute in CreateDefinitionFromAttribute(versionedType))
+            {
+                hasAttributeDefinition = true;
+                yield return definitionFromAttribute;
+            }
+
+            if (hasAttributeDefinition) yield break;
+            
             yield return CreateDefinitionFromName(versionedType);
         }
 
@@ -225,19 +248,13 @@ namespace EventFlow.Core.VersionedTypes
                 name);
         }
 
-        private TDefinition CreateDefinitionFromAttribute(Type versionedType)
+        private IEnumerable<TDefinition> CreateDefinitionFromAttribute(Type versionedType)
         {
-            var attribute = versionedType
+            return versionedType
                 .GetTypeInfo()
                 .GetCustomAttributes()
                 .OfType<TAttribute>()
-                .SingleOrDefault();
-            return attribute == null
-                ? null
-                : CreateDefinition(
-                    attribute.Version,
-                    versionedType,
-                    attribute.Name);
+                .Select(a => CreateDefinition(a.Version, versionedType, a.Name));
         }
     }
 }

--- a/Source/EventFlow/EventStores/EventVersionAttribute.cs
+++ b/Source/EventFlow/EventStores/EventVersionAttribute.cs
@@ -26,7 +26,10 @@ using EventFlow.Core.VersionedTypes;
 
 namespace EventFlow.EventStores
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(
+        AttributeTargets.Class,
+        AllowMultiple = true
+        )]
     public class EventVersionAttribute : VersionedTypeAttribute
     {
         public EventVersionAttribute(string name, int version)


### PR DESCRIPTION
Useful if by some mistake the same event made it to production using different names by mistake.