### PR TITLE
ReflectionHelper.CompileMethodInvocation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 ### New in 0.53 (not released yet)
 
 * New: Allow events to have multiple `EventVersion` attributes
+* Fixed: `ReflectionHelper.CompileMethodInvocation` now recognises
+  `private` methods.
 
 ### New in 0.52.3178 (released 2017-11-02)
 

--- a/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Core/ReflectionHelperTests.cs
@@ -89,12 +89,12 @@ namespace EventFlow.Tests.UnitTests.Core
                 return a + b;
             }
 
-            public Number Add(Number a, Number b)
+            private Number Add(Number a, Number b)
             {
                 return new Number {I = Add(a.I, b.I)};
             }
 
-            public Number Add(Number a, int b)
+            private Number Add(Number a, int b)
             {
                 return new Number { I = Add(a.I, b) };
             }

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -51,10 +51,13 @@ namespace EventFlow.Core
         public static TResult CompileMethodInvocation<TResult>(Type type, string methodName, params Type[] methodSignature)
         {
             var typeInfo = type.GetTypeInfo();
+            var methods = typeInfo
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => m.Name == methodName);
 
             var methodInfo = methodSignature == null || !methodSignature.Any()
-                ? typeInfo.GetMethods(BindingFlags.Instance | BindingFlags.Public).SingleOrDefault(m => m.Name == methodName)
-                : typeInfo.GetMethod(methodName, methodSignature);
+                ? methods.SingleOrDefault()
+                : methods.SingleOrDefault(m => m.GetParameters().Select(mp => mp.ParameterType).SequenceEqual(methodSignature));
 
             if (methodInfo == null)
             {


### PR DESCRIPTION
http://docs.geteventflow.net/Aggregates.html#events states that Appy method _can_ be `private`



 - recognise private methods
 - update test