### PR TITLE
Fix: Concurrent access to InMemoryEventPersistence

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### New in 0.57 (not released yet)
 
-* _Nothing yet_
+* Fixed: AggregateException/InvalidOperationException when reading and updating
+  an aggregate from different threads at the same time using `InMemoryEventPersistence`
 
 ### New in 0.56.3328 (released 2018-04-24)
 
@@ -21,7 +22,6 @@
   - EventFlow.Elasticsearch
   - EventFlow.Hangfire
   - EventFlow.Sql
-* Fixed: AggregateException/InvalidOperationException when reading and updating an aggregate from different threads at the same time using InMemoryEventPersistence
 
 ### New in 0.54.3261 (released 2018-02-25)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
   - EventFlow.Elasticsearch
   - EventFlow.Hangfire
   - EventFlow.Sql
+* Fixed: AggregateException/InvalidOperationException when reading and updating an aggregate from different threads at the same time using InMemoryEventPersistence
 
 ### New in 0.54.3261 (released 2018-02-25)
 

--- a/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/EventStores/ConcurrentInMemoryEventPersistanceTests.cs
@@ -1,0 +1,164 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Configuration;
+using EventFlow.Core;
+using EventFlow.EventStores;
+using EventFlow.EventStores.InMemory;
+using EventFlow.Exceptions;
+using EventFlow.Logs;
+using EventFlow.Snapshots;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Events;
+using EventFlow.TestHelpers.Aggregates.ValueObjects;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace EventFlow.Tests.UnitTests.EventStores
+{
+    [Category(Categories.Unit)]
+    public class ConcurrentInMemoryEventPersistanceTests
+    {
+        // Higher values have exponential effect on duration
+        // due to OptimsticConcurrency and retry
+        private const int DegreeOfParallelism = 5;
+        private const int NumberOfEvents = 100;
+
+        // All threads operate on same thingy
+        private static readonly ThingyId ThingyId = ThingyId.New;
+
+        [Test]
+        public void MultipleInstances()
+        {
+            var store = CreateStore();
+
+            // Arrange
+            var tasks = RunInParallel(async i =>
+            {
+                await CommitEventsAsync(store).ConfigureAwait(false);
+            });
+
+            // Act
+            Task.WaitAll(tasks.ToArray());
+
+            // Assert
+            var allEvents = store.LoadAllEventsAsync(GlobalPosition.Start, Int32.MaxValue, CancellationToken.None);
+            allEvents.Result.DomainEvents.Count.Should().Be(NumberOfEvents * DegreeOfParallelism);
+        }
+
+        private EventStoreBase CreateStore()
+        {
+            var aggregateFactory = Mock.Of<IAggregateFactory>();
+            var resolver = Mock.Of<IResolver>();
+            var metadataProviders = Enumerable.Empty<IMetadataProvider>();
+            var snapshotStore = Mock.Of<ISnapshotStore>();
+            var log = new NullLog();
+            var factory = new DomainEventFactory();
+            var persistence = new InMemoryEventPersistence(log);
+            var upgradeManager = new EventUpgradeManager(log, resolver);
+            var definitionService = new EventDefinitionService(log);
+            definitionService.Load(typeof(ThingyPingEvent));
+            var serializer = new EventJsonSerializer(new JsonSerializer(), definitionService, factory);
+
+            var store = new EventStoreBase(log, aggregateFactory,
+                serializer, upgradeManager, metadataProviders,
+                persistence, snapshotStore);
+
+            return store;
+        }
+
+        private async Task CommitEventsAsync(EventStoreBase store)
+        {
+            var events = new[]
+            {
+                new ThingyPingEvent(PingId.New),
+            };
+
+            for (int i = 0; i < NumberOfEvents; i++)
+            {
+                await RetryAsync(async () =>
+                {
+                    var allEvents = await store.LoadEventsAsync<ThingyAggregate, ThingyId>(ThingyId,
+                        CancellationToken.None).ConfigureAwait(false);
+
+                    var version = allEvents.Count;
+                    var serializedEvents
+                        = from aggregateEvent in events
+                          let metadata = new Metadata
+                          {
+                              AggregateSequenceNumber = ++version,
+                              AggregateName = "ThingyAggregate",
+                              Timestamp = DateTimeOffset.Now
+                          }
+                          let uncommittedEvent = new UncommittedEvent(aggregateEvent, metadata)
+                          select uncommittedEvent;
+
+                    var readOnlyEvents = new ReadOnlyCollection<UncommittedEvent>(serializedEvents.ToList());
+
+                    await store.StoreAsync<ThingyAggregate, ThingyId>(ThingyId, readOnlyEvents,
+                            SourceId.New, CancellationToken.None)
+                            .ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            }
+        }
+
+        private static IEnumerable<Task> RunInParallel(Func<int, Task> action)
+        {
+            var tasks = Enumerable.Range(1, DegreeOfParallelism)
+                .AsParallel()
+                .WithDegreeOfParallelism(DegreeOfParallelism)
+                .Select(action);
+
+            return tasks.ToList();
+        }
+
+        private static readonly Random Random = new Random();
+
+        private static async Task RetryAsync(Func<Task> action)
+        {
+            for (int retry = 0; retry < 100; retry++)
+            {
+                try
+                {
+                    await action().ConfigureAwait(false);
+                    return;
+                }
+                catch (OptimisticConcurrencyException)
+                {
+                    await Task.Delay(Random.Next(100, 1000));
+                }
+            }
+
+            throw new Exception("Retried too often.");
+        }
+    }
+}

--- a/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
+++ b/Source/EventFlow/EventStores/InMemory/InMemoryEventPersistence.cs
@@ -22,6 +22,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -41,8 +42,8 @@ namespace EventFlow.EventStores.InMemory
     {
         private readonly ILog _log;
 
-        private readonly ConcurrentDictionary<string, List<InMemoryCommittedDomainEvent>> _eventStore =
-            new ConcurrentDictionary<string, List<InMemoryCommittedDomainEvent>>();
+        private readonly ConcurrentDictionary<string, ImmutableEventCollection> _eventStore =
+            new ConcurrentDictionary<string, ImmutableEventCollection>();
 
         private readonly AsyncLock _asyncLock = new AsyncLock();
 
@@ -79,6 +80,35 @@ namespace EventFlow.EventStores.InMemory
                 {
                     return json;
                 }
+            }
+        }
+
+        private class ImmutableEventCollection : IReadOnlyCollection<InMemoryCommittedDomainEvent>
+        {
+            private readonly List<InMemoryCommittedDomainEvent> _events;
+
+            public ImmutableEventCollection(List<InMemoryCommittedDomainEvent> events)
+            {
+                _events = events;
+            }
+
+            public int Count => _events.Count;
+
+            public InMemoryCommittedDomainEvent Last => _events.Last();
+
+            public ImmutableEventCollection Add(List<InMemoryCommittedDomainEvent> events)
+            {
+                return new ImmutableEventCollection(_events.Concat(events).ToList());
+            }
+
+            public IEnumerator<InMemoryCommittedDomainEvent> GetEnumerator()
+            {
+                return _events.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
             }
         }
 
@@ -122,18 +152,7 @@ namespace EventFlow.EventStores.InMemory
 
             using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))
             {
-                var globalCount = _eventStore.Values.SelectMany(e => e).Count();
-
-                List<InMemoryCommittedDomainEvent> committedDomainEvents;
-                if (_eventStore.ContainsKey(id.Value))
-                {
-                    committedDomainEvents = _eventStore[id.Value];
-                }
-                else
-                {
-                    committedDomainEvents = new List<InMemoryCommittedDomainEvent>();
-                    _eventStore[id.Value] = committedDomainEvents;
-                }
+                var globalCount = _eventStore.Values.Sum(events => events.Count);
 
                 var newCommittedDomainEvents = serializedEvents
                     .Select((e, i) =>
@@ -153,45 +172,50 @@ namespace EventFlow.EventStores.InMemory
                     .ToList();
 
                 var expectedVersion = newCommittedDomainEvents.First().AggregateSequenceNumber - 1;
-                if (expectedVersion != committedDomainEvents.Count)
+                var lastEvent = newCommittedDomainEvents.Last();
+
+                var updateResult = _eventStore.AddOrUpdate(id.Value, s => new ImmutableEventCollection(newCommittedDomainEvents),
+                    (s, collection) => collection.Count == expectedVersion 
+                        ? collection.Add(newCommittedDomainEvents) 
+                        : collection);
+
+                if (updateResult.Last != lastEvent)
                 {
                     throw new OptimisticConcurrencyException("");
                 }
-
-                committedDomainEvents.AddRange(newCommittedDomainEvents);
 
                 return newCommittedDomainEvents;
             }
         }
 
-        public async Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync(
+        public Task<IReadOnlyCollection<ICommittedDomainEvent>> LoadCommittedEventsAsync(
             IIdentity id,
             int fromEventSequenceNumber,
             CancellationToken cancellationToken)
         {
-            using (await _asyncLock.WaitAsync(cancellationToken).ConfigureAwait(false))
-            {
-                List<InMemoryCommittedDomainEvent> committedDomainEvent;
-                return _eventStore.TryGetValue(id.Value, out committedDomainEvent)
-                    ? fromEventSequenceNumber <= 1 ? committedDomainEvent : committedDomainEvent.Where(e => e.AggregateSequenceNumber >= fromEventSequenceNumber).ToList()
-                    : new List<InMemoryCommittedDomainEvent>();
-            }
+            IReadOnlyCollection<ICommittedDomainEvent> result;
+
+            if (_eventStore.TryGetValue(id.Value, out var committedDomainEvent))
+                result = fromEventSequenceNumber <= 1
+                    ? (IReadOnlyCollection<ICommittedDomainEvent>) committedDomainEvent
+                    : committedDomainEvent.Where(e => e.AggregateSequenceNumber >= fromEventSequenceNumber).ToList();
+            else
+                result = new List<InMemoryCommittedDomainEvent>();
+
+            return Task.FromResult(result);
         }
 
         public Task DeleteEventsAsync(IIdentity id, CancellationToken cancellationToken)
         {
-            if (!_eventStore.ContainsKey(id.Value))
+            var deleted = _eventStore.TryRemove(id.Value, out var committedDomainEvents);
+
+            if (deleted)
             {
-                return Task.FromResult(0);
+                _log.Verbose(
+                    "Deleted entity with ID '{0}' by deleting all of its {1} events",
+                    id,
+                    committedDomainEvents.Count);
             }
-
-            List<InMemoryCommittedDomainEvent> committedDomainEvents;
-            _eventStore.TryRemove(id.Value, out committedDomainEvents);
-
-            _log.Verbose(
-                "Deleted entity with ID '{0}' by deleting all of its {1} events",
-                id,
-                committedDomainEvents.Count);
 
             return Task.FromResult(0);
         }


### PR DESCRIPTION
This fixes #444 

As there is no ImmutableCollection in .NET Standard 1.6, I made an append-only `ImmutableEventCollection` that implements `IReadOnlyCollection` and can be safely returned from `LoadCommittedEventsAsync` without copying it all the time. 

First I tried making it a linked list of lists, so that committing would just append a node with the new events and enumerating would yield all events from the first node up to the current one, ignoring any next nodes, which would effectively make it immutable and enumeration-safe. But that made no difference performance-wise, so I went for the easier implementation that just wraps a list.

I looked into making `CommitEventsAsync` work without locks, but calculating the global sequence number just didn't work: The `ConcurrentDictionary.AddOrUpdate` method can only make atomic updates based on a single aggregate.

This bug happened because an `IReadOnlyCollection` deceives us into being immutable, while even `List<T>` implements it which obviously can be mutated any time.