### PR TITLE
Change Primary Key name for MSSQL Snapshot Store

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 * Fix: Commands are now correctly published when no events are emitted from a saga
   after handling a domain event
+* Minor fix: Updated name of Primary Key for MSSQL Snapshot Store to be different
+  from MSSQL Event Store, so both can be used in the same database without conflicts
 
 ### New in 0.58.3377 (released 2018-05-15)
 

--- a/Source/EventFlow.MsSql/SnapshotStores/Scripts/0001 - Create EventFlowSnapshots.sql
+++ b/Source/EventFlow.MsSql/SnapshotStores/Scripts/0001 - Create EventFlowSnapshots.sql
@@ -7,7 +7,7 @@ BEGIN
 		[AggregateSequenceNumber] [int] NOT NULL,
 		[Data] [nvarchar](MAX) NOT NULL,
 		[Metadata] [nvarchar](MAX) NOT NULL,
-		CONSTRAINT [PK_EventFlow] PRIMARY KEY CLUSTERED
+		CONSTRAINT [PK_EventFlowSnapshots] PRIMARY KEY CLUSTERED
 		(
 			[Id] ASC
 		)


### PR DESCRIPTION
### Problem ###

Using MSSQL EventStore and SnapshotStore in the same database seems to cause conflicts:

```
System.Data.SqlClient.SqlException (0x80131904): There is already an object named 'PK_EventFlow' in the database.
Could not create constraint or index. See previous errors.
```


### Solution ###

Renaming the snapshot PK to `PK_EventFlowSnapshots` seems to do the trick.