### PR TITLE
Fixed CommandPublishMiddleware as to return error, if exception occurs.

### DIFF
--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTests.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/SiteTests.cs
@@ -21,12 +21,14 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using EventFlow.Logs;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates.Commands;
+using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Newtonsoft.Json;
@@ -72,6 +74,15 @@ namespace EventFlow.AspNetCore.Tests.IntegrationTests.Site
 
 			// Act
 			await PostAsync("commands/ThingyPing/1", pingCommand).ConfigureAwait(false);
+		}
+
+		[Test]
+		public void PublishCommand_WithNull_ThrowsException()
+		{
+			// Arrange + Act
+			Action action = () => Task.WaitAll(PostAsync("commands/ThingyPing/1", null));
+
+			action.ShouldThrow<HttpRequestException>("because of command is null.");
 		}
 
 		private async Task<string> GetAsync(string url)

--- a/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
@@ -124,8 +124,8 @@ namespace EventFlow.Aspnetcore.Middlewares
         private async Task WriteAsync(object obj, HttpStatusCode statusCode, HttpContext context)
         {
             var json = _jsonSerializer.Serialize(obj);
-            await context.Response.WriteAsync(json).ConfigureAwait(false);
             context.Response.StatusCode = (int) statusCode;
+            await context.Response.WriteAsync(json).ConfigureAwait(false);
         }
 
         private Task WriteErrorAsync(string errorMessage, HttpStatusCode statusCode, HttpContext context)

--- a/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
+++ b/Source/EventFlow.Owin.Tests/IntegrationTests/Site/SiteTests.cs
@@ -22,9 +22,11 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates.Commands;
+using FluentAssertions;
 using Microsoft.Owin.Hosting;
 using NUnit.Framework;
 
@@ -66,6 +68,15 @@ namespace EventFlow.Owin.Tests.IntegrationTests.Site
 
             // Act
             await PostAsync("commands/ThingyPing/1", pingCommand).ConfigureAwait(false);
+        }
+
+        [Test]
+        public void PublishCommand_WithNull_ThrowsException()
+        {
+            // Arrange + Act
+            Action action = () => Task.WaitAll(PostAsync("commands/ThingyPing/1", null));
+
+            action.ShouldThrow<HttpRequestException>("because of command is null.");
         }
 
         private Task<string> GetAsync(string url)

--- a/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.Owin/Middlewares/CommandPublishMiddleware.cs
@@ -123,8 +123,8 @@ namespace EventFlow.Owin.Middlewares
         private async Task WriteAsync(object obj, HttpStatusCode statusCode, IOwinContext owinContext)
         {
             var json = _jsonSerializer.Serialize(obj);
-            await owinContext.Response.WriteAsync(json).ConfigureAwait(false);
             owinContext.Response.StatusCode = (int) statusCode;
+            await owinContext.Response.WriteAsync(json).ConfigureAwait(false);
         }
 
         private Task WriteErrorAsync(string errorMessage, HttpStatusCode statusCode, IOwinContext owinContext)


### PR DESCRIPTION
Adjusted the position of setting response status code to return proper status code, if catches exception. Also, added tests.

Please refer to the followings. (OWIN side, too. Fixed it)
[Set response status in ASP.NET core middleware - Stack Overflow](https://stackoverflow.com/questions/41966599/set-response-status-in-asp-net-core-middleware)