### PR TITLE
Mark read models for deletion

### DIFF
--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyReadModel.cs
@@ -32,7 +32,8 @@ namespace EventFlow.Elasticsearch.Tests.IntegrationTests.ReadModels
     [ElasticsearchType(IdProperty = "Id", Name = "thingy")]
     public class ElasticsearchThingyReadModel : IReadModel,
         IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent>,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDeletedEvent>
     {
         [Keyword(
             Index = true)]
@@ -59,6 +60,11 @@ namespace EventFlow.Elasticsearch.Tests.IntegrationTests.ReadModels
         {
             Id = domainEvent.AggregateIdentity.Value;
             PingsReceived++;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyDeletedEvent> domainEvent)
+        {
+            context.MarkForDeletion();
         }
 
         public Thingy ToThingy()

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyReadModel.cs
@@ -35,7 +35,8 @@ namespace EventFlow.MsSql.Tests.IntegrationTests.ReadStores.ReadModels
     [Table("ReadModel-ThingyAggregate")]
     public class MsSqlThingyReadModel : MssqlReadModel,
         IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent>,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDeletedEvent>
     {
         public bool DomainErrorAfterFirstReceived { get; set; }
         public int PingsReceived { get; set; }
@@ -48,6 +49,11 @@ namespace EventFlow.MsSql.Tests.IntegrationTests.ReadStores.ReadModels
         public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent> domainEvent)
         {
             DomainErrorAfterFirstReceived = true;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyDeletedEvent> domainEvent)
+        {
+            context.MarkForDeletion();
         }
 
         public Thingy ToThingy()

--- a/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
+++ b/Source/EventFlow.SQLite.Tests/IntegrationTests/ReadStores/ReadModels/SQliteThingyReadModel.cs
@@ -33,7 +33,8 @@ namespace EventFlow.SQLite.Tests.IntegrationTests.ReadStores.ReadModels
     [Table("ReadModel-ThingyAggregate")]
     public class SQLiteThingyReadModel : IReadModel,
         IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent>,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDeletedEvent>
     {
         [SqlReadModelIdentityColumn]
         public string AggregateId { get; set; }
@@ -53,6 +54,11 @@ namespace EventFlow.SQLite.Tests.IntegrationTests.ReadStores.ReadModels
         public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent> domainEvent)
         {
             DomainErrorAfterFirstReceived = true;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyDeletedEvent> domainEvent)
+        {
+            context.MarkForDeletion();
         }
 
         public Thingy ToThingy()

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Commands;
+using EventFlow.TestHelpers.Aggregates.ValueObjects;
+
+namespace EventFlow.TestHelpers.Aggregates.Commands
+{
+    [CommandVersion("ThingyDelete", 1)]
+    public class ThingyDeleteCommand : Command<ThingyAggregate, ThingyId>
+    {
+        public PingId PingId { get; }
+
+        public ThingyDeleteCommand(ThingyId aggregateId) : base(aggregateId)
+        {
+        }
+    }
+
+    public class ThingyDeleteCommandHandler : CommandHandler<ThingyAggregate, ThingyId, ThingyDeleteCommand>
+    {
+        public override Task ExecuteAsync(ThingyAggregate aggregate, ThingyDeleteCommand command, CancellationToken cancellationToken)
+        {
+            aggregate.Delete();
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
@@ -1,0 +1,10 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace EventFlow.TestHelpers.Aggregates.Events
+{
+    [EventVersion("ThingyDeleted", 1)]
+    public class ThingyDeletedEvent : AggregateEvent<ThingyAggregate, ThingyId>
+    {
+    }
+}

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
@@ -58,6 +58,7 @@ namespace EventFlow.TestHelpers.Aggregates
             Register<ThingyMessageAddedEvent>(e => _messages.Add(e.ThingyMessage));
             Register<ThingySagaStartRequestedEvent>(e => {/* do nothing */});
             Register<ThingySagaCompleteRequestedEvent>(e => {/* do nothing */});
+            Register<ThingyDeletedEvent>(e => {/* do nothing */});
         }
 
         public void DomainErrorAfterFirst()
@@ -120,6 +121,11 @@ namespace EventFlow.TestHelpers.Aggregates
             _pingsReceived.AddRange(snapshot.PingsReceived);
             SnapshotVersions = snapshot.PreviousVersions;
             return Task.FromResult(0);
+        }
+
+        public void Delete()
+        {
+            Emit(new ThingyDeletedEvent());
         }
     }
 }

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
@@ -269,6 +269,29 @@ namespace EventFlow.TestHelpers.Suites
             readModel.PingsReceived.Should().Be(3);
         }
 
+        [Test]
+        public async Task MarkingForDeletionRemovesSpecificReadModel()
+        {
+            // Arrange
+            var id1 = ThingyId.New;
+            var id2 = ThingyId.New;
+            await PublishPingCommandAsync(id1).ConfigureAwait(false);
+            await PublishPingCommandAsync(id2).ConfigureAwait(false);
+            var readModel1 = await QueryProcessor.ProcessAsync(new ThingyGetQuery(id1)).ConfigureAwait(false);
+            var readModel2 = await QueryProcessor.ProcessAsync(new ThingyGetQuery(id2)).ConfigureAwait(false);
+            readModel1.Should().NotBeNull();
+            readModel2.Should().NotBeNull();
+
+            // Act
+            await CommandBus.PublishAsync(new ThingyDeleteCommand(id1), CancellationToken.None);
+
+            // Assert
+            readModel1 = await QueryProcessor.ProcessAsync(new ThingyGetQuery(id1)).ConfigureAwait(false);
+            readModel2 = await QueryProcessor.ProcessAsync(new ThingyGetQuery(id2)).ConfigureAwait(false);
+            readModel1.Should().BeNull();
+            readModel2.Should().NotBeNull();
+        }
+
         private class WaitState
         {
             public AutoResetEvent ReadStoreReady { get; } = new AutoResetEvent(false);

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyReadModel.cs
@@ -30,7 +30,8 @@ namespace EventFlow.Tests.IntegrationTests.ReadStores.ReadModels
 {
     public class InMemoryThingyReadModel : IReadModel,
         IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent>,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDeletedEvent>
     {
         public ThingyId ThingyId { get; private set; }
         public bool DomainErrorAfterFirstReceived { get; private set; }
@@ -46,6 +47,11 @@ namespace EventFlow.Tests.IntegrationTests.ReadStores.ReadModels
         {
             ThingyId = domainEvent.AggregateIdentity;
             PingsReceived++;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyDeletedEvent> domainEvent)
+        {
+            context.MarkForDeletion();
         }
 
         public Thingy ToThingy()

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -99,7 +99,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             ReadModelStoreMock.Verify(
                 s => s.UpdateAsync(
                     It.IsAny<IReadOnlyCollection<ReadModelUpdate>>(),
-                    It.IsAny<IReadModelContext>(),
+                    It.IsAny<Func<IReadModelContext>>(),
                     It.IsAny<Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<ReadStoreManagerTestReadModel>, CancellationToken, Task<ReadModelEnvelope<ReadStoreManagerTestReadModel>>>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
@@ -71,7 +71,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             ReadModelStoreMock.Verify(
                 s => s.UpdateAsync(
                     It.Is<IReadOnlyCollection<ReadModelUpdate>>(l => l.Count == 1),
-                    It.IsAny<IReadModelContext>(),
+                    It.IsAny<Func<IReadModelContext>>(),
                     It.IsAny<Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<ReadStoreManagerTestReadModel>, CancellationToken, Task<ReadModelEnvelope<ReadStoreManagerTestReadModel>>>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);

--- a/Source/EventFlow/ReadStores/IReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContext.cs
@@ -28,5 +28,7 @@ namespace EventFlow.ReadStores
     public interface IReadModelContext
     {
         IResolver Resolver { get; }
+        void MarkForDeletion();
+        bool IsMarkedForDeletion { get; }
     }
 }

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -46,10 +46,10 @@ namespace EventFlow.ReadStores
             string id,
             CancellationToken cancellationToken);
 
-        Task UpdateAsync(
-            IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
-            IReadModelContext readModelContext,
-            Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken, Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
+        Task UpdateAsync(IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
+            Func<IReadModelContext> readModelContextFactory,
+            Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken,
+                Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow/ReadStores/ReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContext.cs
@@ -27,12 +27,18 @@ namespace EventFlow.ReadStores
 {
     public class ReadModelContext : IReadModelContext
     {
-        public IResolver Resolver { get; }
-
-        public ReadModelContext(
-            IResolver resolver)
+        public ReadModelContext(IResolver resolver)
         {
             Resolver = resolver;
+        }
+
+        public bool IsMarkedForDeletion { get; private set; }
+
+        public IResolver Resolver { get; }
+
+        public void MarkForDeletion()
+        {
+            IsMarkedForDeletion = true;
         }
     }
 }

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -52,10 +52,10 @@ namespace EventFlow.ReadStores
         public abstract Task DeleteAllAsync(
             CancellationToken cancellationToken);
 
-        public abstract Task UpdateAsync(
-            IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
-            IReadModelContext readModelContext,
-            Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken, Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
+        public abstract Task UpdateAsync(IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
+            Func<IReadModelContext> readModelContextFactory,
+            Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken,
+                Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -111,7 +111,8 @@ namespace EventFlow.ReadStores
                 typeof(TReadModelStore).PrettyPrint(),
                 string.Join(", ", relevantDomainEvents.Select(e => e.ToString()))));
 
-            var readModelContext = new ReadModelContext(Resolver);
+            IReadModelContext ReadModelContextFactory() => new ReadModelContext(Resolver);
+
             var readModelUpdates = BuildReadModelUpdates(relevantDomainEvents);
 
             if (!readModelUpdates.Any())
@@ -126,7 +127,7 @@ namespace EventFlow.ReadStores
 
             await ReadModelStore.UpdateAsync(
                 readModelUpdates,
-                readModelContext,
+                ReadModelContextFactory,
                 UpdateAsync,
                 cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
Finally some use for the `IReadModelContext`:

``` csharp
public class InMemoryThingyReadModel : IReadModel,
    IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDeletedEvent>
{
    public void Apply(IReadModelContext context, 
        IDomainEvent<ThingyAggregate, ThingyId, ThingyDeletedEvent> domainEvent)
    {
        context.MarkForDeletion();
    }
}