### PR TITLE
ApplyEvents: Better support for snapshots

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,9 @@
   - `UseElasticsearchReadModelFor<,,>`
   - `UseMssqlReadModelFor<,,>`
   - `UseSQLiteReadModelFor<,,>`
+* Minor: Applying events to a snapshot will now have the correct `Version` set 
+  inside the `Apply` methods.
+* Minor: Trying to apply events in the wrong order will now throw an exception.
 
 ### New in 0.61.3524 (released 2018-06-26)
 

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyDeleteCommand.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Commands;
 using EventFlow.TestHelpers.Aggregates.ValueObjects;

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyDeletedEvent.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Aggregates;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
 using EventFlow.EventStores;
 
 namespace EventFlow.TestHelpers.Aggregates.Events

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Aggregates;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Entities;
 
 namespace EventFlow.TestHelpers.Aggregates.Events

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContext.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 
 namespace EventFlow.TestHelpers.Aggregates.Queries
 {

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQuery.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Queries;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Queries;
 
 namespace EventFlow.TestHelpers.Aggregates.Queries
 {

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/DbContextQueryHandler.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Queries;
 

--- a/Source/EventFlow.TestHelpers/Aggregates/Queries/IDbContext.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Queries/IDbContext.cs
@@ -1,4 +1,27 @@
-﻿namespace EventFlow.TestHelpers.Aggregates.Queries
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace EventFlow.TestHelpers.Aggregates.Queries
 {
     public interface IDbContext 
     {

--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -135,22 +135,9 @@ namespace EventFlow.Aggregates
             return domainEvents;
         }
 
-        public void ApplyEvents(IReadOnlyCollection<IDomainEvent> domainEvents, int fromVersion = 0)
+        public void ApplyEvents(IReadOnlyCollection<IDomainEvent> domainEvents)
         {
             if (domainEvents == null) throw new ArgumentNullException(nameof(domainEvents));
-
-            if (Version > 0)
-            {
-                throw new InvalidOperationException($"Aggregate '{GetType().PrettyPrint()}' with ID '{Id}' already has events");
-            }
-
-            if (!domainEvents.Any())
-            {
-                Version = fromVersion;
-                return;
-            }
-
-            Version = fromVersion;
 
             foreach (var domainEvent in domainEvents)
             {

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -41,9 +41,7 @@ namespace EventFlow.Aggregates
 
         bool HasSourceId(ISourceId sourceId);
 
-        void ApplyEvents(IEnumerable<IAggregateEvent> aggregateEvents);
-
-        void ApplyEvents(IReadOnlyCollection<IDomainEvent> domainEvents);
+        void ApplyEvents(IReadOnlyCollection<IDomainEvent> domainEvents, int fromVersion = 0);
 
         IIdentity GetIdentity();
 

--- a/Source/EventFlow/Aggregates/IAggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/IAggregateRoot.cs
@@ -41,7 +41,7 @@ namespace EventFlow.Aggregates
 
         bool HasSourceId(ISourceId sourceId);
 
-        void ApplyEvents(IReadOnlyCollection<IDomainEvent> domainEvents, int fromVersion = 0);
+        void ApplyEvents(IReadOnlyCollection<IDomainEvent> domainEvents);
 
         IIdentity GetIdentity();
 

--- a/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
@@ -1,4 +1,27 @@
-﻿namespace EventFlow.ReadStores
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace EventFlow.ReadStores
 {
     public interface IReadModelContextFactory
     {

--- a/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
@@ -1,4 +1,27 @@
-﻿using EventFlow.Configuration;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Configuration;
 
 namespace EventFlow.ReadStores
 {

--- a/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
@@ -69,18 +69,14 @@ namespace EventFlow.Snapshots
 
             await LoadSnapshotContainerAsync(snapshot, cancellationToken).ConfigureAwait(false);
 
+            var version = snapshot.Metadata.AggregateSequenceNumber;
             var domainEvents = await eventStore.LoadEventsAsync<TAggregate, TIdentity>(
                 Id,
-                snapshot.Metadata.AggregateSequenceNumber + 1,
+                version + 1,
                 cancellationToken)
                 .ConfigureAwait(false);
-            if (!domainEvents.Any())
-            {
-                Version = snapshot.Metadata.AggregateSequenceNumber;
-                return;
-            }
 
-            ApplyEvents(domainEvents);
+            ApplyEvents(domainEvents, version);
         }
 
         public override async Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(

--- a/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
+++ b/Source/EventFlow/Snapshots/SnapshotAggregateRoot.cs
@@ -69,14 +69,15 @@ namespace EventFlow.Snapshots
 
             await LoadSnapshotContainerAsync(snapshot, cancellationToken).ConfigureAwait(false);
 
-            var version = snapshot.Metadata.AggregateSequenceNumber;
+            Version = snapshot.Metadata.AggregateSequenceNumber;
+
             var domainEvents = await eventStore.LoadEventsAsync<TAggregate, TIdentity>(
                 Id,
-                version + 1,
+                Version + 1,
                 cancellationToken)
                 .ConfigureAwait(false);
 
-            ApplyEvents(domainEvents, version);
+            ApplyEvents(domainEvents);
         }
 
         public override async Task<IReadOnlyCollection<IDomainEvent>> CommitAsync(


### PR DESCRIPTION
> - Aggregates must not assume that snapshots are created with increasing aggregate sequence numbers
>
> *Snapshot documentation*

I still managed to create a bug because of not having the actual Version value inside the `Apply` methods when snapshots were used.

This PR changes how events are applied in regard to aggregate sequence numbers:
- Possibly breaking: Removed `ApplyEvents(IEnumerable<IAggregateEvent>)`, which was only used by `AggregateRoot` itself and inlined it, in order to validate the current version for each applied event.
- Added `fromVersion` parameter: Sets the starting version after checking for initial state.
- Removed `domainEvents.Max(e => e.AggregateSequenceNumber)` because the Version should already be incremented