### PR TITLE
ReadModelContext: Added ReadModelId and IsNew

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,9 @@
   - `UseElasticsearchReadModelFor<,,>`
   - `UseMssqlReadModelFor<,,>`
   - `UseSQLiteReadModelFor<,,>`
+* New: Added `ReadModelId` and `IsNew` properties to the context object that is
+  available to a read model inside the `Apply` methods in order to better support
+  scenarios where a single event affects multiple read model instances. 
 
 ### New in 0.61.3524 (released 2018-06-26)
 

--- a/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
+++ b/Source/EventFlow.Elasticsearch.Tests/IntegrationTests/ReadModels/ElasticsearchThingyMessageReadModel.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Linq;
 using EventFlow.Aggregates;
 using EventFlow.ReadStores;
 using EventFlow.TestHelpers.Aggregates;
@@ -32,7 +33,8 @@ namespace EventFlow.Elasticsearch.Tests.IntegrationTests.ReadModels
 {
     [ElasticsearchType(IdProperty = "Id", Name = "message")]
     public class ElasticsearchThingyMessageReadModel : IReadModel,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageHistoryAddedEvent>
     {
         public string Id { get; set; }
 
@@ -52,6 +54,16 @@ namespace EventFlow.Elasticsearch.Tests.IntegrationTests.ReadModels
 
             var thingyMessage = domainEvent.AggregateEvent.ThingyMessage;
             Id = thingyMessage.Id.Value;
+            Message = thingyMessage.Message;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyMessageHistoryAddedEvent> domainEvent)
+        {
+            ThingyId = domainEvent.AggregateIdentity.Value;
+
+            var messageId = new ThingyMessageId(context.ReadModelId);
+            var thingyMessage = domainEvent.AggregateEvent.ThingyMessages.Single(m => m.Id == messageId);
+            Id = messageId.Value;
             Message = thingyMessage.Message;
         }
 

--- a/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
+++ b/Source/EventFlow.Elasticsearch/ReadStores/ElasticsearchReadModelStore.cs
@@ -122,18 +122,17 @@ namespace EventFlow.Elasticsearch.ReadStores
         }
 
         public async Task UpdateAsync(IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
-            Func<IReadModelContext> readModelContextFactory,
+            IReadModelContextFactory readModelContextFactory,
             Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken,
                 Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken)
         {
             var readModelDescription = _readModelDescriptionProvider.GetReadModelDescription<TReadModel>();
-            var readModelContext = readModelContextFactory();
 
             foreach (var readModelUpdate in readModelUpdates)
             {
                 await _transientFaultHandler.TryAsync(
-                    c => UpdateReadModelAsync(readModelDescription, readModelUpdate, readModelContext, updateReadModel, c),
+                    c => UpdateReadModelAsync(readModelDescription, readModelUpdate, readModelContextFactory, updateReadModel, c),
                     Label.Named("elasticsearch-read-model-update"),
                     cancellationToken)
                     .ConfigureAwait(false);
@@ -143,12 +142,14 @@ namespace EventFlow.Elasticsearch.ReadStores
         private async Task UpdateReadModelAsync(
             ReadModelDescription readModelDescription,
             ReadModelUpdate readModelUpdate,
-            IReadModelContext readModelContext,
+            IReadModelContextFactory readModelContextFactory,
             Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken, Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken)
         {
+            var readModelId = readModelUpdate.ReadModelId;
+
             var response = await _elasticClient.GetAsync<TReadModel>(
-                readModelUpdate.ReadModelId,
+                readModelId,
                 d => d
                     .RequestConfiguration(c => c
                         .AllowedStatusCodes((int)HttpStatusCode.NotFound))
@@ -156,21 +157,25 @@ namespace EventFlow.Elasticsearch.ReadStores
                             cancellationToken)
                 .ConfigureAwait(false);
 
-            var readModelEnvelope = response.Found
-                ? ReadModelEnvelope<TReadModel>.With(readModelUpdate.ReadModelId, response.Source, response.Version, false)
-                : ReadModelEnvelope<TReadModel>.Empty(readModelUpdate.ReadModelId);
+            var isNew = !response.Found;
+
+            var readModelEnvelope = isNew
+                ? ReadModelEnvelope<TReadModel>.Empty(readModelId)
+                : ReadModelEnvelope<TReadModel>.With(readModelId, response.Source, response.Version, false);
+
+            var context = readModelContextFactory.Create(readModelId, isNew);
 
             readModelEnvelope = await updateReadModel(
-                readModelContext,
+                context,
                 readModelUpdate.DomainEvents,
                 readModelEnvelope,
                 cancellationToken)
                 .ConfigureAwait(false);
             if (!readModelEnvelope.IsModified) return;
 
-            if (readModelContext.IsMarkedForDeletion)
+            if (context.IsMarkedForDeletion)
             {
-                await DeleteAsync(readModelUpdate.ReadModelId, cancellationToken).ConfigureAwait(false);
+                await DeleteAsync(readModelId, cancellationToken).ConfigureAwait(false);
                 return;
             }
 
@@ -182,11 +187,11 @@ namespace EventFlow.Elasticsearch.ReadStores
                     {
                         d = d
                             .RequestConfiguration(c => c)
-                            .Id(readModelUpdate.ReadModelId)
+                            .Id(readModelId)
                             .Index(readModelDescription.IndexName.Value);
-                        d = response.Found
-                            ? d.VersionType(VersionType.ExternalGte).Version(readModelEnvelope.Version.GetValueOrDefault())
-                            : d.OpType(OpType.Create);
+                        d = isNew
+                            ? d.OpType(OpType.Create)
+                            : d.VersionType(VersionType.ExternalGte).Version(readModelEnvelope.Version.GetValueOrDefault());
                         return d;
                     },
                     cancellationToken)
@@ -196,7 +201,7 @@ namespace EventFlow.Elasticsearch.ReadStores
                 when (e.Response?.HttpStatusCode == (int)HttpStatusCode.Conflict)
             {
                 throw new OptimisticConcurrencyException(
-                    $"Read model '{readModelUpdate.ReadModelId}' updated by another",
+                    $"Read model '{readModelId}' updated by another",
                     e);
             }
         }

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/ReadStores/ReadModels/MsSqlThingyMessageReadModel.cs
@@ -22,6 +22,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using EventFlow.Aggregates;
 using EventFlow.MsSql.ReadStores.Attributes;
 using EventFlow.ReadStores;
@@ -33,7 +34,8 @@ namespace EventFlow.MsSql.Tests.IntegrationTests.ReadStores.ReadModels
 {
     [Table("ReadModel-ThingyMessage")]
     public class MsSqlThingyMessageReadModel : IReadModel,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageHistoryAddedEvent>
     {
         public string ThingyId { get; set; }
 
@@ -48,6 +50,16 @@ namespace EventFlow.MsSql.Tests.IntegrationTests.ReadStores.ReadModels
 
             var thingyMessage = domainEvent.AggregateEvent.ThingyMessage;
             MessageId = thingyMessage.Id.Value;
+            Message = thingyMessage.Message;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyMessageHistoryAddedEvent> domainEvent)
+        {
+            ThingyId = domainEvent.AggregateIdentity.Value;
+
+            var messageId = new ThingyMessageId(context.ReadModelId);
+            var thingyMessage = domainEvent.AggregateEvent.ThingyMessages.Single(m => m.Id == messageId);
+            MessageId = messageId.Value;
             Message = thingyMessage.Message;
         }
 

--- a/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
+++ b/Source/EventFlow.Sql/ReadModels/SqlReadModelStore.cs
@@ -99,17 +99,15 @@ namespace EventFlow.Sql.ReadModels
         }
 
         public override async Task UpdateAsync(IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
-            Func<IReadModelContext> readModelContextFactory,
+            IReadModelContextFactory readModelContextFactory,
             Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken,
                 Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken)
         {
             foreach (var readModelUpdate in readModelUpdates)
             {
-                var readModelContext = readModelContextFactory();
-
                 await _transientFaultHandler.TryAsync(
-                    c => UpdateReadModelAsync(readModelContext, updateReadModel, c, readModelUpdate),
+                    c => UpdateReadModelAsync(readModelContextFactory, updateReadModel, c, readModelUpdate),
                     Label.Named("sql-read-model-update"),
                     cancellationToken)
                     .ConfigureAwait(false);
@@ -117,21 +115,24 @@ namespace EventFlow.Sql.ReadModels
         }
 
         private async Task UpdateReadModelAsync(
-            IReadModelContext readModelContext,
+            IReadModelContextFactory readModelContextFactory,
             Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken, Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken,
             ReadModelUpdate readModelUpdate)
         {
+            var readModelId = readModelUpdate.ReadModelId;
             var readModelNameLowerCased = typeof(TReadModel).Name.ToLowerInvariant();
-            var readModelEnvelope = await GetAsync(readModelUpdate.ReadModelId, cancellationToken).ConfigureAwait(false);
+            var readModelEnvelope = await GetAsync(readModelId, cancellationToken).ConfigureAwait(false);
             var readModel = readModelEnvelope.ReadModel;
             var isNew = readModel == null;
 
             if (readModel == null)
             {
-                readModel = await _readModelFactory.CreateAsync(readModelUpdate.ReadModelId, cancellationToken).ConfigureAwait(false);
-                readModelEnvelope = ReadModelEnvelope<TReadModel>.With(readModelUpdate.ReadModelId, readModel, false);
+                readModel = await _readModelFactory.CreateAsync(readModelId, cancellationToken).ConfigureAwait(false);
+                readModelEnvelope = ReadModelEnvelope<TReadModel>.With(readModelId, readModel, false);
             }
+
+            var readModelContext = readModelContextFactory.Create(readModelId, isNew);
 
             var originalVersion = readModelEnvelope.Version;
             readModelEnvelope = await updateReadModel(
@@ -144,7 +145,7 @@ namespace EventFlow.Sql.ReadModels
 
             if (readModelContext.IsMarkedForDeletion)
             {
-                await DeleteAsync(readModelUpdate.ReadModelId, cancellationToken).ConfigureAwait(false);
+                await DeleteAsync(readModelId, cancellationToken).ConfigureAwait(false);
                 return;
             }
 
@@ -173,7 +174,7 @@ namespace EventFlow.Sql.ReadModels
                     $"Read model '{readModelEnvelope.ReadModelId}' updated by another");
             }
 
-            Log.Verbose(() => $"Updated SQL read model {typeof(TReadModel).PrettyPrint()} with ID '{readModelUpdate.ReadModelId}' to version '{readModelEnvelope.Version}'");
+            Log.Verbose(() => $"Updated SQL read model {typeof(TReadModel).PrettyPrint()} with ID '{readModelId}' to version '{readModelEnvelope.Version}'");
         }
 
         public override async Task<ReadModelEnvelope<TReadModel>> GetAsync(string id, CancellationToken cancellationToken)

--- a/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Commands/ThingyAddMessageHistoryCommand.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Commands;
+using EventFlow.TestHelpers.Aggregates.Entities;
+
+namespace EventFlow.TestHelpers.Aggregates.Commands
+{
+    public class ThingyAddMessageHistoryCommand : Command<ThingyAggregate, ThingyId>
+    {
+        public ThingyMessage[] ThingyMessages { get; }
+
+        public ThingyAddMessageHistoryCommand(
+            ThingyId aggregateId,
+            IEnumerable<ThingyMessage> thingyMessages)
+            : base(aggregateId)
+        {
+            ThingyMessages = thingyMessages.ToArray();
+        }
+    }
+
+    public class ThingyAddMessageHistoryCommandHandler : CommandHandler<ThingyAggregate, ThingyId, ThingyAddMessageHistoryCommand>
+    {
+        public override Task ExecuteAsync(ThingyAggregate aggregate, ThingyAddMessageHistoryCommand command, CancellationToken cancellationToken)
+        {
+            aggregate.AddMessageHistory(command.ThingyMessages);
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Entities/ThingyMessageLocator.cs
@@ -32,13 +32,20 @@ namespace EventFlow.TestHelpers.Aggregates.Entities
     {
         public IEnumerable<string> GetReadModelIds(IDomainEvent domainEvent)
         {
-            var messageAddedEvent = domainEvent as IDomainEvent<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>;
-            if (messageAddedEvent == null)
+            var aggregateEvent = domainEvent.GetAggregateEvent();
+            switch (aggregateEvent)
             {
-                yield break;
-            }
+                case ThingyMessageAddedEvent messageAddedEvent:
+                    yield return messageAddedEvent.ThingyMessage.Id.Value;
+                    break;
 
-            yield return messageAddedEvent.AggregateEvent.ThingyMessage.Id.Value;
+                case ThingyMessageHistoryAddedEvent messageHistoryAddedEvent:
+                    foreach (var message in messageHistoryAddedEvent.ThingyMessages)
+                    {
+                        yield return message.Id.Value;
+                    }
+                    break;
+            }
         }
     }
 }

--- a/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/Events/ThingyMessageHistoryAddedEvent.cs
@@ -1,0 +1,15 @@
+﻿using EventFlow.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Entities;
+
+namespace EventFlow.TestHelpers.Aggregates.Events
+{
+    public class ThingyMessageHistoryAddedEvent : AggregateEvent<ThingyAggregate, ThingyId>
+    {
+        public ThingyMessageHistoryAddedEvent(ThingyMessage[] thingyMessages)
+        {
+            ThingyMessages = thingyMessages;
+        }
+
+        public ThingyMessage[] ThingyMessages { get; }
+    }
+}

--- a/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
+++ b/Source/EventFlow.TestHelpers/Aggregates/ThingyAggregate.cs
@@ -56,6 +56,7 @@ namespace EventFlow.TestHelpers.Aggregates
         {
             Register<ThingyPingEvent>(e => _pingsReceived.Add(e.PingId));
             Register<ThingyMessageAddedEvent>(e => _messages.Add(e.ThingyMessage));
+            Register<ThingyMessageHistoryAddedEvent>(e => _messages.AddRange(e.ThingyMessages));
             Register<ThingySagaStartRequestedEvent>(e => {/* do nothing */});
             Register<ThingySagaCompleteRequestedEvent>(e => {/* do nothing */});
             Register<ThingyDeletedEvent>(e => {/* do nothing */});
@@ -79,6 +80,18 @@ namespace EventFlow.TestHelpers.Aggregates
             }
 
             Emit(new ThingyMessageAddedEvent(message));
+        }
+
+        public void AddMessageHistory(ThingyMessage[] messages)
+        {
+            var existingIds = _messages.Select(m => m.Id).Intersect(_messages.Select(m => m.Id)).ToArray();
+            if (existingIds.Any())
+            {
+                throw DomainError.With($"Thingy '{Id}' already has messages with IDs " +
+                                       $"'{string.Join(",", existingIds.Select(id => id.ToString()))}'");
+            }
+
+            Emit(new ThingyMessageHistoryAddedEvent(messages));
         }
 
         public void Ping(PingId pingId)

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForReadModelStore.cs
@@ -292,6 +292,23 @@ namespace EventFlow.TestHelpers.Suites
             readModel2.Should().NotBeNull();
         }
 
+        [Test]
+        public async Task CanStoreMessageHistory()
+        {
+            // Arrange
+            var thingyId = ThingyId.New;
+            var thingyMessages = Fixture.CreateMany<ThingyMessage>(5).ToList();
+            var command = new ThingyAddMessageHistoryCommand(thingyId, thingyMessages);
+            await CommandBus.PublishAsync(command, CancellationToken.None);
+
+            // Act
+            var returnedThingyMessages = await QueryProcessor.ProcessAsync(new ThingyGetMessagesQuery(thingyId)).ConfigureAwait(false);
+
+            // Assert
+            returnedThingyMessages.Should().HaveCount(thingyMessages.Count);
+            returnedThingyMessages.ShouldAllBeEquivalentTo(thingyMessages);
+        }
+
         private class WaitState
         {
             public AutoResetEvent ReadStoreReady { get; } = new AutoResetEvent(false);

--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/ReadModels/InMemoryThingyMessageReadModel.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Linq;
 using EventFlow.Aggregates;
 using EventFlow.ReadStores;
 using EventFlow.TestHelpers.Aggregates;
@@ -30,7 +31,8 @@ using EventFlow.TestHelpers.Aggregates.Events;
 namespace EventFlow.Tests.IntegrationTests.ReadStores.ReadModels
 {
     public class InMemoryThingyMessageReadModel : IReadModel,
-        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageAddedEvent>,
+        IAmReadModelFor<ThingyAggregate, ThingyId, ThingyMessageHistoryAddedEvent>
     {
         public ThingyId ThingyId { get; private set; }
         public ThingyMessageId ThingyMessageId { get; private set; }
@@ -41,6 +43,16 @@ namespace EventFlow.Tests.IntegrationTests.ReadStores.ReadModels
             ThingyId = domainEvent.AggregateIdentity;
 
             var thingyMessage = domainEvent.AggregateEvent.ThingyMessage;
+            ThingyMessageId = thingyMessage.Id;
+            Message = thingyMessage.Message;
+        }
+
+        public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyMessageHistoryAddedEvent> domainEvent)
+        {
+            ThingyId = domainEvent.AggregateIdentity;
+
+            var messageId = new ThingyMessageId(context.ReadModelId);
+            var thingyMessage = domainEvent.AggregateEvent.ThingyMessages.Single(m => m.Id == messageId);
             ThingyMessageId = thingyMessage.Id;
             Message = thingyMessage.Message;
         }

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -99,7 +99,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             ReadModelStoreMock.Verify(
                 s => s.UpdateAsync(
                     It.IsAny<IReadOnlyCollection<ReadModelUpdate>>(),
-                    It.IsAny<Func<IReadModelContext>>(),
+                    It.IsAny<IReadModelContextFactory>(),
                     It.IsAny<Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<ReadStoreManagerTestReadModel>, CancellationToken, Task<ReadModelEnvelope<ReadStoreManagerTestReadModel>>>>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadStoreManagerTestSuite.cs
@@ -96,7 +96,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             ReadModelStoreMock.Verify(
                 s => s.UpdateAsync(
                     It.Is<IReadOnlyCollection<ReadModelUpdate>>(l => l.Count == 1),
-                    It.IsAny<Func<IReadModelContext>>(),
+                    It.IsAny<IReadModelContextFactory>(),
                     It.IsAny<Func<
                         IReadModelContext,
                         IReadOnlyCollection<IDomainEvent>,
@@ -117,7 +117,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             ReadModelStoreMock
                 .Setup(m => m.UpdateAsync(
                     It.IsAny<IReadOnlyCollection<ReadModelUpdate>>(),
-                    It.IsAny<Func<IReadModelContext>>(),
+                    It.IsAny<IReadModelContextFactory>(),
                     It.IsAny<Func<
                         IReadModelContext,
                         IReadOnlyCollection<IDomainEvent>,
@@ -127,7 +127,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
                     It.IsAny<CancellationToken>()))
                 .Callback<
                     IReadOnlyCollection<ReadModelUpdate>,
-                    Func<IReadModelContext>,
+                    IReadModelContextFactory,
                     Func<
                         IReadModelContext,
                         IReadOnlyCollection<IDomainEvent>,
@@ -143,7 +143,7 @@ namespace EventFlow.Tests.UnitTests.ReadStores
                                         foreach (var readModelEnvelope in g)
                                         {
                                             resultingReadModelEnvelopes.Add(updaterFunc(
-                                                readModelContextFactory(),
+                                                readModelContextFactory.Create(readModelEnvelope.ReadModelId, true),
                                                 readModelUpdates
                                                     .Where(d => d.ReadModelId == g.Key)
                                                     .SelectMany(d => d.DomainEvents)

--- a/Source/EventFlow/ReadStores/IReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContext.cs
@@ -30,5 +30,6 @@ namespace EventFlow.ReadStores
         IResolver Resolver { get; }
         void MarkForDeletion();
         bool IsMarkedForDeletion { get; }
+        string ReadModelId { get; }
     }
 }

--- a/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/IReadModelContextFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace EventFlow.ReadStores
+{
+    public interface IReadModelContextFactory
+    {
+        IReadModelContext Create(string readModelId, bool isNew);
+    }
+}

--- a/Source/EventFlow/ReadStores/IReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/IReadModelStore.cs
@@ -47,7 +47,7 @@ namespace EventFlow.ReadStores
             CancellationToken cancellationToken);
 
         Task UpdateAsync(IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
-            Func<IReadModelContext> readModelContextFactory,
+            IReadModelContextFactory readModelContextFactory,
             Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken,
                 Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken);

--- a/Source/EventFlow/ReadStores/ReadModelContext.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContext.cs
@@ -27,12 +27,18 @@ namespace EventFlow.ReadStores
 {
     public class ReadModelContext : IReadModelContext
     {
-        public ReadModelContext(IResolver resolver)
+        public ReadModelContext(IResolver resolver, string readModelId, bool isNew)
         {
             Resolver = resolver;
+            ReadModelId = readModelId;
+            IsNew = isNew;
         }
 
         public bool IsMarkedForDeletion { get; private set; }
+
+        public bool IsNew { get; }
+
+        public string ReadModelId { get; }
 
         public IResolver Resolver { get; }
 

--- a/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
+++ b/Source/EventFlow/ReadStores/ReadModelContextFactory.cs
@@ -1,0 +1,19 @@
+﻿using EventFlow.Configuration;
+
+namespace EventFlow.ReadStores
+{
+    public class ReadModelContextFactory : IReadModelContextFactory
+    {
+        private readonly IResolver _resolver;
+
+        public ReadModelContextFactory(IResolver resolver)
+        {
+            _resolver = resolver;
+        }
+
+        public IReadModelContext Create(string readModelId, bool isNew)
+        {
+            return new ReadModelContext(_resolver, readModelId, isNew);
+        }
+    }
+}

--- a/Source/EventFlow/ReadStores/ReadModelStore.cs
+++ b/Source/EventFlow/ReadStores/ReadModelStore.cs
@@ -53,7 +53,7 @@ namespace EventFlow.ReadStores
             CancellationToken cancellationToken);
 
         public abstract Task UpdateAsync(IReadOnlyCollection<ReadModelUpdate> readModelUpdates,
-            Func<IReadModelContext> readModelContextFactory,
+            IReadModelContextFactory readModelContextFactory,
             Func<IReadModelContext, IReadOnlyCollection<IDomainEvent>, ReadModelEnvelope<TReadModel>, CancellationToken,
                 Task<ReadModelEnvelope<TReadModel>>> updateReadModel,
             CancellationToken cancellationToken);

--- a/Source/EventFlow/ReadStores/ReadStoreManager.cs
+++ b/Source/EventFlow/ReadStores/ReadStoreManager.cs
@@ -105,7 +105,7 @@ namespace EventFlow.ReadStores
                 typeof(TReadModelStore).PrettyPrint(),
                 string.Join(", ", relevantDomainEvents.Select(e => e.ToString()))));
 
-            IReadModelContext ReadModelContextFactory() => new ReadModelContext(Resolver);
+            var contextFactory = new ReadModelContextFactory(Resolver);
 
             var readModelUpdates = BuildReadModelUpdates(relevantDomainEvents);
 
@@ -121,7 +121,7 @@ namespace EventFlow.ReadStores
 
             await ReadModelStore.UpdateAsync(
                 readModelUpdates,
-                ReadModelContextFactory,
+                contextFactory,
                 UpdateAsync,
                 cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
- Adds new properties to the `ReadModelContext`:
    - `ReadModelId` contains the ID, in order to support one-to-many scenarios
    - `IsNew` contains a value that indicates if this readmodel is being created
- Adds `ThingyMessageHistoryAddedEvent` as an example for one-to-many read models