### PR TITLE
Fix: Stack overflow in ValidateRegistrations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@
 ### New in 0.64.3598 (released 2018-08-24)
 
 * New: Added .NET standard support for SQLite
+* Minor: Fixed stack overflow in `ValidateRegistrations` when decorator
+  components are co-located together with other components that are registed using
+  `Add*`-methods
 
 ### New in 0.63.3581 (released 2018-08-07)
 

--- a/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ResolverTests.cs
@@ -21,10 +21,15 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Threading.Tasks;
 using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using EventFlow.Extensions;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Commands;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -63,6 +68,25 @@ namespace EventFlow.Tests.IntegrationTests
                     .NotBeNull()
                     .And
                     .BeOfType<Service>();
+            }
+        }
+
+        [Test]
+        public void RegistrationDoesntCauseStackOverflow()
+        {
+            try
+            {
+                using (var resolver = EventFlowOptions.New
+                    .AddDefaults(EventFlowTestHelpers.Assembly)
+                    .CreateResolver())
+                {
+                    resolver.Resolve<ICommandHandler<ThingyAggregate, ThingyId, IExecutionResult, ThingyAddMessageCommand>>();
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
             }
         }
     }

--- a/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsCommandHandlerExtensions.cs
@@ -39,7 +39,8 @@ namespace EventFlow.Extensions
             predicate = predicate ?? (t => true);
             var commandHandlerTypes = fromAssembly
                 .GetTypes()
-                .Where(t => t.GetTypeInfo().GetInterfaces().Any(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommandHandler<,,,>)))
+                .Where(t => t.GetTypeInfo().GetInterfaces().Any(IsCommandHandlerInterface))
+                .Where(t => !t.HasConstructorParameterOfType(IsCommandHandlerInterface))
                 .Where(t => predicate(t));
             return eventFlowOptions.AddCommandHandlers(commandHandlerTypes);
         }
@@ -62,7 +63,7 @@ namespace EventFlow.Extensions
                 var handlesCommandTypes = t
                     .GetTypeInfo()
                     .GetInterfaces()
-                    .Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommandHandler<,,,>))
+                    .Where(IsCommandHandlerInterface)
                     .ToList();
                 if (!handlesCommandTypes.Any())
                 {
@@ -79,6 +80,11 @@ namespace EventFlow.Extensions
             }
 
             return eventFlowOptions;
+        }
+
+        private static bool IsCommandHandlerInterface(this Type type)
+        {
+            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(ICommandHandler<,,,>);
         }
     }
 }

--- a/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsEventUpgradersExtensions.cs
@@ -60,7 +60,8 @@ namespace EventFlow.Extensions
             predicate = predicate ?? (t => true);
             var eventUpgraderTypes = fromAssembly
                 .GetTypes()
-                .Where(t => t.GetTypeInfo().GetInterfaces().Any(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IEventUpgrader<,>)))
+                .Where(t => t.GetTypeInfo().GetInterfaces().Any(IsEventUpgraderInterface))
+                .Where(t => !t.HasConstructorParameterOfType(IsEventUpgraderInterface))
                 .Where(t => predicate(t));
             return eventFlowOptions
                 .AddEventUpgraders(eventUpgraderTypes);
@@ -85,7 +86,7 @@ namespace EventFlow.Extensions
                 var eventUpgraderForAggregateType = t
                     .GetTypeInfo()
                     .GetInterfaces()
-                    .SingleOrDefault(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IEventUpgrader<,>));
+                    .SingleOrDefault(IsEventUpgraderInterface);
                 if (eventUpgraderForAggregateType == null)
                 {
                     throw new ArgumentException($"Type '{eventUpgraderType.Name}' does not have the '{typeof(IEventUpgrader<,>).PrettyPrint()}' interface");
@@ -95,6 +96,11 @@ namespace EventFlow.Extensions
             }
 
             return eventFlowOptions;
+        }
+
+        private static bool IsEventUpgraderInterface(Type type)
+        {
+            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IEventUpgrader<,>);
         }
     }
 }

--- a/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsMetadataProvidersExtensions.cs
@@ -57,7 +57,8 @@ namespace EventFlow.Extensions
             predicate = predicate ?? (t => true);
             var metadataProviderTypes = fromAssembly
                 .GetTypes()
-                .Where(t => typeof(IMetadataProvider).GetTypeInfo().IsAssignableFrom(t))
+                .Where(IsMetadataProvider)
+                .Where(t => !t.HasConstructorParameterOfType(IsMetadataProvider))
                 .Where(t => predicate(t));
             return eventFlowOptions.AddMetadataProviders(metadataProviderTypes);
         }
@@ -66,18 +67,22 @@ namespace EventFlow.Extensions
             this IEventFlowOptions eventFlowOptions,
             IEnumerable<Type> metadataProviderTypes)
         {
-            foreach (var metadataProviderType in metadataProviderTypes)
+            foreach (var t in metadataProviderTypes)
             {
-                var t = metadataProviderType;
                 if (t.GetTypeInfo().IsAbstract) continue;
-                if (!typeof(IMetadataProvider).GetTypeInfo().IsAssignableFrom(t))
+                if (!t.IsMetadataProvider())
                 {
-                    throw new ArgumentException($"Type '{metadataProviderType.PrettyPrint()}' is not an '{typeof(IMetadataProvider).PrettyPrint()}'");
+                    throw new ArgumentException($"Type '{t.PrettyPrint()}' is not an '{typeof(IMetadataProvider).PrettyPrint()}'");
                 }
 
                 eventFlowOptions.RegisterServices(sr => sr.Register(typeof(IMetadataProvider), t));
             }
             return eventFlowOptions;
+        }
+
+        private static bool IsMetadataProvider(this Type type)
+        {
+            return type.IsAssignableTo<IMetadataProvider>();
         }
     }
 }

--- a/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsQueriesExtensions.cs
@@ -54,7 +54,8 @@ namespace EventFlow.Extensions
             predicate = predicate ?? (t => true);
             var subscribeSynchronousToTypes = fromAssembly
                 .GetTypes()
-                .Where(t => t.GetTypeInfo().GetInterfaces().Any(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IQueryHandler<,>)))
+                .Where(t => t.GetTypeInfo().GetInterfaces().Any(IsQueryHandlerInterface))
+                .Where(t => !t.HasConstructorParameterOfType(IsQueryHandlerInterface))
                 .Where(t => predicate(t));
             return eventFlowOptions
                 .AddQueryHandlers(subscribeSynchronousToTypes);
@@ -71,7 +72,7 @@ namespace EventFlow.Extensions
                 var queryHandlerInterfaces = t
                     .GetTypeInfo()
                     .GetInterfaces()
-                    .Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IQueryHandler<,>))
+                    .Where(IsQueryHandlerInterface)
                     .ToList();
                 if (!queryHandlerInterfaces.Any())
                 {
@@ -88,6 +89,11 @@ namespace EventFlow.Extensions
             }
 
             return eventFlowOptions;
+        }
+
+        private static bool IsQueryHandlerInterface(this Type type)
+        {
+            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(IQueryHandler<,>);
         }
     }
 }

--- a/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSagasExtensions.cs
@@ -39,7 +39,7 @@ namespace EventFlow.Extensions
             predicate = predicate ?? (t => true);
             var sagaTypes = fromAssembly
                 .GetTypes()
-                .Where(t => !t.GetTypeInfo().IsAbstract && typeof(ISaga).GetTypeInfo().IsAssignableFrom(t))
+                .Where(t => !t.GetTypeInfo().IsAbstract && t.IsAssignableTo<ISaga>())
                 .Where(t => predicate(t));
 
             return eventFlowOptions.AddSagas(sagaTypes);
@@ -60,7 +60,8 @@ namespace EventFlow.Extensions
             predicate = predicate ?? (t => true);
             var sagaTypes = fromAssembly
                 .GetTypes()
-                .Where(t => !t.GetTypeInfo().IsAbstract && typeof(ISagaLocator).GetTypeInfo().IsAssignableFrom(t))
+                .Where(t => !t.GetTypeInfo().IsAbstract && t.IsAssignableTo<ISagaLocator>())
+                .Where(t => !t.HasConstructorParameterOfType(x => x.IsAssignableTo<ISagaLocator>()))
                 .Where(t => predicate(t));
 
             return eventFlowOptions.AddSagaLocators(sagaTypes);

--- a/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -64,7 +64,8 @@ namespace EventFlow.Extensions
             var snapshotUpgraderTypes = fromAssembly
                 .GetTypes()
                 .Where(t => !t.GetTypeInfo().IsAbstract)
-                .Where(t => t.GetTypeInfo().GetInterfaces().Any(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(ISnapshotUpgrader<,>)))
+                .Where(t => t.GetTypeInfo().GetInterfaces().Any(IsSnapshotUpgraderInterface))
+                .Where(t => !t.HasConstructorParameterOfType(IsSnapshotUpgraderInterface))
                 .Where(t => predicate(t));
 
             return eventFlowOptions.AddSnapshotUpgraders(snapshotUpgraderTypes);
@@ -88,7 +89,7 @@ namespace EventFlow.Extensions
                         var interfaceType = snapshotUpgraderType
                             .GetTypeInfo()
                             .GetInterfaces()
-                            .Single(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(ISnapshotUpgrader<,>));
+                            .Single(IsSnapshotUpgraderInterface);
                         sr.Register(interfaceType, snapshotUpgraderType);
                     }
                 });
@@ -106,6 +107,11 @@ namespace EventFlow.Extensions
             this IEventFlowOptions eventFlowOptions)
         {
             return eventFlowOptions.UseSnapshotStore<InMemorySnapshotPersistence>(Lifetime.Singleton);
+        }
+
+        private static bool IsSnapshotUpgraderInterface(Type type)
+        {
+            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(ISnapshotUpgrader<,>);
         }
     }
 }

--- a/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsSubscriberExtensions.cs
@@ -33,6 +33,10 @@ namespace EventFlow.Extensions
 {
     public static class EventFlowOptionsSubscriberExtensions
     {
+        private static readonly Type ISubscribeSynchronousToType = typeof(ISubscribeSynchronousTo<,,>);
+        private static readonly Type ISubscribeAsynchronousToType = typeof(ISubscribeAsynchronousTo<,,>);
+        private static readonly Type ISubscribeSynchronousToAllType = typeof(ISubscribeSynchronousToAll);
+
         [Obsolete("Please use the more explicit method 'AddSynchronousSubscriber<,,,>' instead")]
         public static IEventFlowOptions AddSubscriber<TAggregate, TIdentity, TEvent, TSubscriber>(
             this IEventFlowOptions eventFlowOptions)
@@ -69,9 +73,9 @@ namespace EventFlow.Extensions
 
         public static IEventFlowOptions AddSubscribers(
             this IEventFlowOptions eventFlowOptions,
-            params Type[] subscribeSynchronousToTypes)
+            params Type[] types)
         {
-            return eventFlowOptions.AddSubscribers((IEnumerable<Type>) subscribeSynchronousToTypes);
+            return eventFlowOptions.AddSubscribers((IEnumerable<Type>) types);
         }
 
         public static IEventFlowOptions AddSubscribers(
@@ -79,31 +83,19 @@ namespace EventFlow.Extensions
             Assembly fromAssembly,
             Predicate<Type> predicate = null)
         {
-            var iSubscribeSynchronousToType = typeof(ISubscribeSynchronousTo<,,>);
-            var iSubscribeAsynchronousToType = typeof(ISubscribeAsynchronousTo<,,>);
-            var iSubscribeSynchronousToAllType = typeof(ISubscribeSynchronousToAll);
-
             predicate = predicate ?? (t => true);
-            var subscribeSynchronousToTypes = fromAssembly
+            var types = fromAssembly
                 .GetTypes()
-                .Where(t => t
-                    .GetTypeInfo()
-                    .GetInterfaces()
-                    .Any(i =>
-                        i.GetTypeInfo().IsGenericType && (i.GetGenericTypeDefinition() == iSubscribeSynchronousToType || i.GetGenericTypeDefinition() == iSubscribeAsynchronousToType) ||
-                        i == iSubscribeSynchronousToAllType))
+                .Where(t => t.GetTypeInfo().GetInterfaces().Any(IsSubscriberInterface))
+                .Where(t => !t.HasConstructorParameterOfType(IsSubscriberInterface))
                 .Where(t => predicate(t));
-            return eventFlowOptions.AddSubscribers(subscribeSynchronousToTypes);
+            return eventFlowOptions.AddSubscribers(types);
         }
 
         public static IEventFlowOptions AddSubscribers(
             this IEventFlowOptions eventFlowOptions,
             IEnumerable<Type> subscribeSynchronousToTypes)
         {
-            var iSubscribeSynchronousToType = typeof(ISubscribeSynchronousTo<,,>);
-            var iSubscribeAsynchronousToType = typeof(ISubscribeAsynchronousTo<,,>);
-            var iSubscribeSynchronousToAllType = typeof(ISubscribeSynchronousToAll);
-
             foreach (var subscribeSynchronousToType in subscribeSynchronousToTypes)
             {
                 var t = subscribeSynchronousToType;
@@ -111,13 +103,11 @@ namespace EventFlow.Extensions
                 var subscribeTos = t
                     .GetTypeInfo()
                     .GetInterfaces()
-                    .Where(i =>
-                        i.GetTypeInfo().IsGenericType && (i.GetGenericTypeDefinition() == iSubscribeSynchronousToType || i.GetGenericTypeDefinition() == iSubscribeAsynchronousToType) ||
-                        i == iSubscribeSynchronousToAllType)
+                    .Where(IsSubscriberInterface)
                     .ToList();
                 if (!subscribeTos.Any())
                 {
-                    throw new ArgumentException($"Type '{t.PrettyPrint()}' is not an '{iSubscribeSynchronousToType.PrettyPrint()}', '{iSubscribeAsynchronousToType.PrettyPrint()}' or '{iSubscribeSynchronousToAllType.PrettyPrint()}'");
+                    throw new ArgumentException($"Type '{t.PrettyPrint()}' is not an '{ISubscribeSynchronousToType.PrettyPrint()}', '{ISubscribeAsynchronousToType.PrettyPrint()}' or '{ISubscribeSynchronousToAllType.PrettyPrint()}'");
                 }
 
                 eventFlowOptions.RegisterServices(sr =>
@@ -130,6 +120,19 @@ namespace EventFlow.Extensions
             }
 
             return eventFlowOptions;
+        }
+
+        private static bool IsSubscriberInterface(Type type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            if (!typeInfo.IsGenericType)
+                return false;
+
+            var genericTypeDefinition = type.GetGenericTypeDefinition();
+
+            return genericTypeDefinition == ISubscribeSynchronousToType ||
+                   genericTypeDefinition == ISubscribeAsynchronousToType ||
+                   type == ISubscribeSynchronousToAllType;
         }
     }
 }

--- a/Source/EventFlow/Extensions/TypeExtensions.cs
+++ b/Source/EventFlow/Extensions/TypeExtensions.cs
@@ -99,6 +99,18 @@ namespace EventFlow.Extensions
                     });
         }
 
+        internal static bool HasConstructorParameterOfType(this Type type, Predicate<Type> predicate)
+        {
+            return type.GetTypeInfo().GetConstructors()
+                .Any(c => c.GetParameters()
+                    .Any(p => predicate(p.ParameterType)));
+        }
+
+        internal static bool IsAssignableTo<T>(this Type type)
+        {
+            return typeof(T).GetTypeInfo().IsAssignableFrom(type);
+        }
+
         internal static IReadOnlyDictionary<Type, Action<T, IAggregateEvent>> GetAggregateEventApplyMethods<TAggregate, TIdentity, T>(this Type type)
             where TAggregate : IAggregateRoot<TIdentity>
             where TIdentity : IIdentity


### PR DESCRIPTION
Added checks in every Add* method for components that could potentially be decorated to filter out any types that have a constructor that takes a dependency on the same interface. This should catch any cases where a decorator gets incorrectly resolved, which leads to a stack overflow exception during resolution.

Added a failing to reproduce the issue.

This fixes #523 