### PR TITLE
Improvement of CI stability and duration time

### DIFF
--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlHelpz.cs
@@ -58,6 +58,7 @@ namespace EventFlow.TestHelpers.MsSql
             connectionstringParts.Add(string.IsNullOrEmpty(envrionmentUsername)
                 ? @"Integrated Security=True"
                 : $"User Id={envrionmentUsername}");
+            connectionstringParts.Add("Connection Timeout=60");
             if (!string.IsNullOrEmpty(environmentPassword))
             {
                 connectionstringParts.Add($"Password={environmentPassword}");

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,7 @@ services:
   - postgresql101
 
 on_success:
-- cmd: docker-compose -f docker-compose.ci.yml stop
-- "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
-- pip install codecov
+- choco install codecov
 - codecov -f "Build\\Reports\\opencover-results.xml"
 
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,8 @@ version: 0.65.{build}
 
 skip_tags: true
 
-before_build:
-  - ps: .\up_integration-test-env.ps1
-
 build_script:
-  - cmd: powershell -NoProfile -ExecutionPolicy unrestricted -Command .\build.ps1 -Target "All"
+  - cmd: powershell -NoProfile -ExecutionPolicy unrestricted -Command ".\up_integration-test-env.ps1; .\build.ps1 -Target All;"
 
 image: Visual Studio 2017
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ services:
   - postgresql101
 
 on_success:
+- cmd: docker-compose -f docker-compose.ci.yml stop
 - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
 - pip install codecov
 - codecov -f "Build\\Reports\\opencover-results.xml"

--- a/build.cake
+++ b/build.cake
@@ -132,12 +132,11 @@ Task("Package")
 							
 				DotNetCorePack(
 					name,
-					new DotNetCorePackSettings
+					new DotNetCorePackSettings()
 					{
 						Configuration = CONFIGURATION,
 						OutputDirectory = DIR_OUTPUT_PACKAGES,
 						NoBuild = true,
-                        Verbosity = DotNetCoreVerbosity.Detailed,
 						ArgumentCustomization = aggs => aggs.Append(GetDotNetCoreArgsVersions())
 					});
 			}

--- a/up_integration-test-env.ps1
+++ b/up_integration-test-env.ps1
@@ -8,13 +8,25 @@ Function Get-Container-Ip($containername)
 # Up containers
 docker-compose -f docker-compose.ci.yml up -d
 
+# Install curl
+cinst curl -y --no-progress
+sal curl (Join-Path $env:ChocolateyInstall "bin\curl.exe") -O AllScope
+
 # Set connection url to environment variable
 # RabbitMQ
-$hostip = Get-Container-Ip rabbitmq-ef
-$env:RABBITMQ_URL = "amqp://guest:guest@${hostip}:5672"
+$rabbitmq_ip = Get-Container-Ip rabbitmq-ef
+$env:RABBITMQ_URL = "amqp://guest:guest@${rabbitmq_ip}:5672"
 # Elasticsearch
-$hostip = Get-Container-Ip elasticsearch-ef
-$env:ELASTICSEARCH_URL = "http://${hostip}:9200"
+$elasticsearch_ip = Get-Container-Ip elasticsearch-ef
+$env:ELASTICSEARCH_URL = "http://${elasticsearch_ip}:9200"
 # Event Store
-$hostip = Get-Container-Ip eventstore-ef
-$env:EVENTSTORE_URL = "tcp://admin:changeit@${hostip}:1113"
+$eventstore_ip = Get-Container-Ip eventstore-ef
+$env:EVENTSTORE_URL = "tcp://admin:changeit@${eventstore_ip}:1113"
+
+# Helth check
+# Event Store
+curl --connect-timeout 60 --retry 5 -sL "http://${eventstore_ip}:2113"
+# Elasticsearch
+curl --connect-timeout 60 --retry 5 -sL "http://${elasticsearch_ip}:9200"
+# RabbitMQ
+curl --connect-timeout 60 --retry 5 -sL "http://${rabbitmq_ip}:15672"

--- a/up_integration-test-env.ps1
+++ b/up_integration-test-env.ps1
@@ -6,6 +6,7 @@ Function Get-Container-Ip($containername)
 # end functions
 
 # Up containers
+docker-compose -f docker-compose.ci.yml pull --parallel
 docker-compose -f docker-compose.ci.yml up -d
 
 # Install curl


### PR DESCRIPTION
#### Description
 - Stability
    - Add containers health check
    - Stop containers before running `codecov`
    - Set `Connection Timeout` to 60 sec in `MsSqlHelpz` 
 - Duration time
    - Pull docker images as parallel
    - Stop outputting publish task verbose
#### Notes
 - This is related to #531