### PR TITLE
Concurrencyfix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ﻿### New in 0.66 (not released yet)
 
-* _Nothing yet_
+*  **Critical fix:** - fix issue where the process using EventFlow could hang using 100% CPU due to unsynchronized Dictionary access, See #541.
 
 ### New in 0.65.3664 (eleased 2018-09-22)
 

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGenerator.cs
@@ -42,11 +42,11 @@ namespace EventFlow.Sql.ReadModels
         private static readonly ConcurrentDictionary<Type, IReadOnlyCollection<PropertyInfo>> PropertyInfos = new ConcurrentDictionary<Type, IReadOnlyCollection<PropertyInfo>>();
         private static readonly ConcurrentDictionary<Type, string> IdentityColumns = new ConcurrentDictionary<Type, string>();
         private static readonly ConcurrentDictionary<Type, string> VersionColumns = new ConcurrentDictionary<Type, string>();
-        private readonly Dictionary<Type, string> _insertSqls = new Dictionary<Type, string>();
-        private readonly Dictionary<Type, string> _purgeSqls = new Dictionary<Type, string>();
-        private readonly Dictionary<Type, string> _deleteSqls = new Dictionary<Type, string>();
-        private readonly Dictionary<Type, string> _selectSqls = new Dictionary<Type, string>();
-        private readonly Dictionary<Type, string> _updateSqls = new Dictionary<Type, string>();
+        private readonly ConcurrentDictionary<Type, string> _insertSqls = new ConcurrentDictionary<Type, string>();
+        private readonly ConcurrentDictionary<Type, string> _purgeSqls = new ConcurrentDictionary<Type, string>();
+        private readonly ConcurrentDictionary<Type, string> _deleteSqls = new ConcurrentDictionary<Type, string>();
+        private readonly ConcurrentDictionary<Type, string> _selectSqls = new ConcurrentDictionary<Type, string>();
+        private readonly ConcurrentDictionary<Type, string> _updateSqls = new ConcurrentDictionary<Type, string>();
 
         public ReadModelSqlGenerator()
         {


### PR DESCRIPTION
Fixes #541 by introducing `ConcurrentDictionary<,'>` over `Dictionary<,>` in `ReadModelSqlGenerator`. 