### PR TITLE
Registering postgresql read model stores with their interfaces instead of their class types. Fixes exceptions on circular component dependencies when using autofac as IoC container.

### DIFF
--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
@@ -40,10 +40,10 @@ namespace EventFlow.PostgreSql.Extensions
                 .RegisterServices(f =>
                     {
                         f.Register<IReadModelSqlGenerator, PostgresReadModelSqlGenerator>(Lifetime.Singleton, true);
-                        f.Register<PostgreSqlReadModelStore<TReadModel>, PostgreSqlReadModelStore<TReadModel>>();
-                        f.Register<IReadModelStore<TReadModel>>(r => r.Resolver.Resolve<PostgreSqlReadModelStore<TReadModel>>());
+                        f.Register<IPostgresReadModelStore<TReadModel>, PostgreSqlReadModelStore<TReadModel>>();
+                        f.Register<IReadModelStore<TReadModel>>(r => r.Resolver.Resolve<IPostgresReadModelStore<TReadModel>>());
                     })
-                .UseReadStoreFor<PostgreSqlReadModelStore<TReadModel>, TReadModel, TReadModelLocator>();
+                .UseReadStoreFor<IPostgresReadModelStore<TReadModel>, TReadModel, TReadModelLocator>();
         }
 
         public static IEventFlowOptions UsePostgreSqlReadModel<TReadModel>(
@@ -54,10 +54,10 @@ namespace EventFlow.PostgreSql.Extensions
                 .RegisterServices(f =>
                     {
                         f.Register<IReadModelSqlGenerator, PostgresReadModelSqlGenerator>(Lifetime.Singleton, true);
-                        f.Register<PostgreSqlReadModelStore<TReadModel>, PostgreSqlReadModelStore<TReadModel>>();
-                        f.Register<IReadModelStore<TReadModel>>(r => r.Resolver.Resolve<PostgreSqlReadModelStore<TReadModel>>());
+                        f.Register<IPostgresReadModelStore<TReadModel>, PostgreSqlReadModelStore<TReadModel>>();
+                        f.Register<IReadModelStore<TReadModel>>(r => r.Resolver.Resolve<IPostgresReadModelStore<TReadModel>>());
                     })
-                .UseReadStoreFor<PostgreSqlReadModelStore<TReadModel>, TReadModel>();
+                .UseReadStoreFor<IPostgresReadModelStore<TReadModel>, TReadModel>();
         }
     }
 }


### PR DESCRIPTION
When using the PostgreSql integration alongside with Autofac intgration, exceptions are thrown for circular component dependencies. As a fix the service registrations for read model stores will be done by using their interfaces instead of their class types. 