### PR TITLE
Rename Aspnetcore to AspNetCore namespace.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+### New in 0.68 (not released yet)
+
+* Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore` to
+   `EventFlow.AspNetCore`
+
+* Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
+
 ### New in 0.67 (not released yet)
 
 * New: Upgrade NEST version to 6.1.0 and Hangfire.Core to 1.6.20

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,7 @@
-### New in 0.68 (not released yet)
-
-* Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore` to
-   `EventFlow.AspNetCore`
-* Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
-
 ### New in 0.67 (not released yet)
 
+* Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore`
+  to `EventFlow.AspNetCore`
 * New: Expose `Lifetime.Scoped` through the EventFLow service registration
   interface
 * New: Upgrade NEST version to 6.1.0 and Hangfire.Core to 1.6.20
@@ -15,6 +11,7 @@
   all indexes linked to the alias.
 * Fix: Internal IoC (remember its just for testing) now correctly invokes
   `IDisposable.Dispose()` on scope and container dispose
+* Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
 
 ### New in 0.66.3673 (released 2018-09-30)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,11 @@
 ### New in 0.68 (not released yet)
 
-* _Nothing yet_
+* Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore`
+  to `EventFlow.AspNetCore`
+* Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
 
 ### New in 0.67.3697 (released 2018-10-14)
 
-* Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore`
-  to `EventFlow.AspNetCore`
 * New: Expose `Lifetime.Scoped` through the EventFLow service registration
   interface
 * New: Upgrade NEST version to 6.1.0 and Hangfire.Core to 1.6.20
@@ -15,7 +15,6 @@
   all indexes linked to the alias.
 * Fix: Internal IoC (remember its just for testing) now correctly invokes
   `IDisposable.Dispose()` on scope and container dispose
-* Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
 
 ### New in 0.66.3673 (released 2018-09-30)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,6 @@
 
 * Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore` to
    `EventFlow.AspNetCore`
-
 * Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
 
 ### New in 0.67 (not released yet)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,6 @@
 
 * Breaking: Changed name of namespace of the projects AspNetCore `EventFlow.Aspnetcore`
   to `EventFlow.AspNetCore`
-* Fix: adjust using dependencies to `using EventFlow.AspNetCore...;`
 
 ### New in 0.67.3697 (released 2018-10-14)
 

--- a/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/Startup.cs
+++ b/Source/EventFlow.AspNetCore.Tests/IntegrationTests/Site/Startup.cs
@@ -24,7 +24,7 @@
 using System;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
-using EventFlow.Aspnetcore.Middlewares;
+using EventFlow.AspNetCore.Middlewares;
 using EventFlow.AspNetCore.Extensions;
 using EventFlow.Autofac.Extensions;
 using EventFlow.Extensions;

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddRequestHeadersMetadataProvider.cs
@@ -29,7 +29,7 @@ using EventFlow.Core;
 using EventFlow.EventStores;
 using Microsoft.AspNetCore.Http;
 
-namespace EventFlow.Aspnetcore.MetadataProviders
+namespace EventFlow.AspNetCore.MetadataProviders
 { 
     public class AddRequestHeadersMetadataProvider : IMetadataProvider
     {

--- a/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
+++ b/Source/EventFlow.AspNetCore/MetadataProviders/AddUserHostAddressMetadataProvider.cs
@@ -29,7 +29,7 @@ using EventFlow.EventStores;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
-namespace EventFlow.Aspnetcore.MetadataProviders
+namespace EventFlow.AspNetCore.MetadataProviders
 {
     public class AddUserHostAddressMetadataProvider : IMetadataProvider
     {

--- a/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
+++ b/Source/EventFlow.AspNetCore/Middlewares/CommandPublishMiddleware.cs
@@ -33,7 +33,7 @@ using EventFlow.Exceptions;
 using EventFlow.Logs;
 using Microsoft.AspNetCore.Http;
 
-namespace EventFlow.Aspnetcore.Middlewares
+namespace EventFlow.AspNetCore.Middlewares
 {
     public class CommandPublishMiddleware
     {


### PR DESCRIPTION
Just fixing the namespace EventFlow.Aspnetcore to EventFlow.AspNetCore.