### PR TITLE
Fix: Use GetRequiredService in EventFlow.DependencyInjection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 ### New in 0.69 (not released yet)
 
 * Fix: Added the schema `dbo` to the `eventdatamodel_list_type` in script `0002 - Create eventdatamodel_list_type.sql` for `EventFlow.MsSql`.
+* Fix: `IResolver.Resolve<T>()` and `IResolver.Resolve(Type)` now throw an
+  exception for unregistered services when using `EventFlow.DependencyInjection`.
 
 ### New in 0.68.3728 (released 2018-12-03)
 

--- a/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
+++ b/Source/EventFlow.DependencyInjection/Registrations/ServiceProviderResolver.cs
@@ -42,12 +42,12 @@ namespace EventFlow.DependencyInjection.Registrations
 
         public T Resolve<T>()
         {
-            return ServiceProvider.GetService<T>();
+            return ServiceProvider.GetRequiredService<T>();
         }
 
         public object Resolve(Type serviceType)
         {
-            return ServiceProvider.GetService(serviceType);
+            return ServiceProvider.GetRequiredService(serviceType);
         }
 
         public IEnumerable<object> ResolveAll(Type serviceType)

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForServiceRegistration.cs
@@ -161,6 +161,22 @@ namespace EventFlow.TestHelpers.Suites
         }
 
         [Test]
+        public void ServiceViaGenericNotFoundThrowsException()
+        {
+            var resolver = Sut.CreateResolver(false);
+            Action callingResolve = () => resolver.Resolve<IMagicInterface>();
+            callingResolve.ShouldThrow<Exception>();
+        }
+
+        [Test]
+        public void ServiceViaTypeNotFoundThrowsException()
+        {
+            var resolver = Sut.CreateResolver(false);
+            Action callingResolve = () => resolver.Resolve(typeof(IMagicInterface));
+            callingResolve.ShouldThrow<Exception>();
+        }
+
+        [Test]
         public void EnumerableTypesAreResolved()
         {
             // Arrange


### PR DESCRIPTION
In `ServiceProviderResolver` we used `ServiceProvider.GetService<T>` which returns `null` for unregistered services. In order to align the behavior with other resolver implementations (and user's expectations), this has been changed to use `GetRequiredService<T>` which throws an exception.

This fixes #574.