### PR TITLE
Async read model updates (IAmAsyncReadModelFor)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ### New in 0.69 (not released yet)
 
+* New: Support for async read model updates (`IAmAsyncReadModelFor`).
+  You can mix and match asynchronous and synchronous updates, 
+  as long as you don't subscribe to the same event in both ways.
 * Fix: Added the schema `dbo` to the `eventdatamodel_list_type` in script `0002 - Create eventdatamodel_list_type.sql` for `EventFlow.MsSql`.
 
 ### New in 0.68.3728 (released 2018-12-03)

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/AggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/AggregateReadStoreManagerTests.cs
@@ -188,7 +188,8 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             {
             }
 
-            public Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent)
+            public Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent,
+                CancellationToken cancellationToken)
             {
                 return Task.FromResult(true);
             }

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/AggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/AggregateReadStoreManagerTests.cs
@@ -22,12 +22,14 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Aggregates;
 using EventFlow.EventStores;
 using EventFlow.ReadStores;
+using EventFlow.ReadStores.InMemory;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Events;
@@ -148,6 +150,48 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             // Assert
             AppliedDomainEvents.Should().HaveCount(storedEvents.Length);
             AppliedDomainEvents.ShouldAllBeEquivalentTo(storedEvents);
+        }
+
+        [Test]
+        public void ThrowsIfReadModelSubscribesNoEvents()
+        {
+            Action a = () =>
+            {
+                var _ = new SingleAggregateReadStoreManager<InMemoryReadStore<ReadModelWithoutEvents>,
+                    ReadModelWithoutEvents>(null, null, null, null, null);
+            };
+
+            a.ShouldThrow<TypeInitializationException>().WithInnerMessage("*does not implement any*");
+        }
+
+        [Test]
+        public void ThrowsIfReadModelSubscribesSameEventTwice()
+        {
+            Action a = () =>
+            {
+                var _ = new SingleAggregateReadStoreManager<InMemoryReadStore<ReadModelWithAmbigiousEvents>,
+                    ReadModelWithAmbigiousEvents>(null, null, null, null, null);
+            };
+
+            a.ShouldThrow<TypeInitializationException>().WithInnerMessage("*implements ambiguous*");
+        }
+
+        private class ReadModelWithoutEvents : IReadModel
+        {
+        }
+
+        private class ReadModelWithAmbigiousEvents : IReadModel,
+            IAmReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>,
+            IAmAsyncReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
+        {
+            public void Apply(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent)
+            {
+            }
+
+            public Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent)
+            {
+                return Task.FromResult(true);
+            }
         }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
@@ -58,6 +58,18 @@ namespace EventFlow.Tests.UnitTests.ReadStores
             }
         }
 
+        public class AsyncPingReadModel : IReadModel,
+            IAmAsyncReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
+        {
+            public bool PingEventsReceived { get; private set; }
+
+            public async Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent)
+            {
+                await Task.Delay(50);
+                PingEventsReceived = true;
+            }
+        }
+
         public class DomainErrorAfterFirstReadModel : IReadModel,
             IAmReadModelFor<ThingyAggregate, ThingyId, ThingyDomainErrorAfterFirstEvent>
         {
@@ -198,6 +210,28 @@ namespace EventFlow.Tests.UnitTests.ReadStores
                     ToDomainEvent(A<ThingyPingEvent>()),
                 };
             var readModel = new PingReadModel();
+
+            // Act
+            await Sut.UpdateReadModelAsync(
+                readModel,
+                events,
+                A<IReadModelContext>(),
+                CancellationToken.None)
+                .ConfigureAwait(false);
+
+            // Assert
+            readModel.PingEventsReceived.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task AsyncReadModelReceivesEvent()
+        {
+            // Arrange
+            var events = new[]
+                {
+                    ToDomainEvent(A<ThingyPingEvent>()),
+                };
+            var readModel = new AsyncPingReadModel();
 
             // Act
             await Sut.UpdateReadModelAsync(

--- a/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/ReadStores/ReadModelDomainEventApplierTests.cs
@@ -63,9 +63,10 @@ namespace EventFlow.Tests.UnitTests.ReadStores
         {
             public bool PingEventsReceived { get; private set; }
 
-            public async Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent)
+            public async Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent,
+                CancellationToken cancellationToken)
             {
-                await Task.Delay(50);
+                await Task.Delay(50, cancellationToken).ConfigureAwait(false);
                 PingEventsReceived = true;
             }
         }

--- a/Source/EventFlow/Core/ReflectionHelper.cs
+++ b/Source/EventFlow/Core/ReflectionHelper.cs
@@ -48,7 +48,8 @@ namespace EventFlow.Core
         /// Handles correct upcast. If no upcast was needed, then this could be exchanged to an <c>Expression.Call</c>
         /// and an <c>Expression.Lambda</c>.
         /// </summary>
-        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName, params Type[] methodSignature)
+        public static TResult CompileMethodInvocation<TResult>(Type type, string methodName,
+            params Type[] methodSignature)
         {
             var typeInfo = type.GetTypeInfo();
             var methods = typeInfo
@@ -64,6 +65,15 @@ namespace EventFlow.Core
                 throw new ArgumentException($"Type '{type.PrettyPrint()}' doesn't have a method called '{methodName}'");
             }
 
+            return CompileMethodInvocation<TResult>(methodInfo);
+        }
+
+        /// <summary>
+        /// Handles correct upcast. If no upcast was needed, then this could be exchanged to an <c>Expression.Call</c>
+        /// and an <c>Expression.Lambda</c>.
+        /// </summary>
+        public static TResult CompileMethodInvocation<TResult>(MethodInfo methodInfo)
+        {
             var genericArguments = typeof(TResult).GetTypeInfo().GetGenericArguments();
             var methodArgumentList = methodInfo.GetParameters().Select(p => p.ParameterType).ToList();
             var funcArgumentList = genericArguments.Skip(1).Take(methodArgumentList.Count).ToList();
@@ -87,6 +97,8 @@ namespace EventFlow.Core
                 {
                     instanceArgument,
                 };
+
+            var type = methodInfo.DeclaringType;
             var instanceVariable = Expression.Variable(type);
             var blockVariables = new List<ParameterExpression>
                 {

--- a/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
@@ -1,0 +1,37 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading.Tasks;
+using EventFlow.Aggregates;
+using EventFlow.Core;
+
+namespace EventFlow.ReadStores
+{
+    public interface IAmAsyncReadModelFor<TAggregate, in TIdentity, in TEvent>
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+        where TEvent : IAggregateEvent<TAggregate, TIdentity>
+    {
+        Task ApplyAsync(IReadModelContext context, IDomainEvent<TAggregate, TIdentity, TEvent> domainEvent);
+    }
+}

--- a/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
+++ b/Source/EventFlow/ReadStores/IAmAsyncReadModelFor.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Aggregates;
 using EventFlow.Core;
@@ -32,6 +33,6 @@ namespace EventFlow.ReadStores
         where TIdentity : IIdentity
         where TEvent : IAggregateEvent<TAggregate, TIdentity>
     {
-        Task ApplyAsync(IReadModelContext context, IDomainEvent<TAggregate, TIdentity, TEvent> domainEvent);
+        Task ApplyAsync(IReadModelContext context, IDomainEvent<TAggregate, TIdentity, TEvent> domainEvent, CancellationToken cancellationToken);
     }
 }

--- a/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
+++ b/Source/EventFlow/ReadStores/ReadModelDomainEventApplier.cs
@@ -34,9 +34,13 @@ namespace EventFlow.ReadStores
 {
     public class ReadModelDomainEventApplier : IReadModelDomainEventApplier
     {
-        private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<Type, Action<IReadModel, IReadModelContext, IDomainEvent>>> ApplyMethods = new ConcurrentDictionary<Type, ConcurrentDictionary<Type, Action<IReadModel, IReadModelContext, IDomainEvent>>>();
+        private const string ApplyMethodName = "Apply";
+        private const string ApplyAsyncMethodName = "ApplyAsync";
 
-        public Task<bool> UpdateReadModelAsync<TReadModel>(
+        private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<Type, ApplyMethod>> ApplyMethods =
+            new ConcurrentDictionary<Type, ConcurrentDictionary<Type, ApplyMethod>>();
+
+        public async Task<bool> UpdateReadModelAsync<TReadModel>(
             TReadModel readModel,
             IReadOnlyCollection<IDomainEvent> domainEvents,
             IReadModelContext readModelContext,
@@ -50,29 +54,73 @@ namespace EventFlow.ReadStores
             {
                 var applyMethods = ApplyMethods.GetOrAdd(
                     readModelType,
-                    t => new ConcurrentDictionary<Type, Action<IReadModel, IReadModelContext, IDomainEvent>>());
+                    t => new ConcurrentDictionary<Type, ApplyMethod>());
                 var applyMethod = applyMethods.GetOrAdd(
                     domainEvent.EventType,
                     t =>
+                    {
+                        var domainEventType = typeof(IDomainEvent<,,>).MakeGenericType(domainEvent.AggregateType,
+                            domainEvent.GetIdentity().GetType(), t);
+
+                        var methodSignature = new[] {typeof(IReadModelContext), domainEventType};
+                        var methodInfo = readModelType.GetTypeInfo().GetMethod(ApplyMethodName, methodSignature);
+
+                        if (methodInfo != null)
                         {
-                            var domainEventType = typeof(IDomainEvent<,,>).MakeGenericType(domainEvent.AggregateType, domainEvent.GetIdentity().GetType(), t);
+                            var method = ReflectionHelper
+                                .CompileMethodInvocation<Action<IReadModel, IReadModelContext, IDomainEvent>>(
+                                    readModelType, ApplyMethodName, methodSignature);
+                            return new ApplyMethod(method);
+                        }
 
-                            var methodSignature = new[] {typeof(IReadModelContext), domainEventType};
-                            var methodInfo = readModelType.GetTypeInfo().GetMethod("Apply", methodSignature);
+                        methodInfo = readModelType.GetTypeInfo().GetMethod(ApplyAsyncMethodName, methodSignature);
 
-                            return methodInfo == null
-                                ? null
-                                : ReflectionHelper.CompileMethodInvocation<Action<IReadModel, IReadModelContext, IDomainEvent>>(readModelType, "Apply", methodSignature);
-                        });
+                        if (methodInfo != null)
+                        {
+                            var method = ReflectionHelper
+                                .CompileMethodInvocation<Func<IReadModel, IReadModelContext, IDomainEvent, Task>>(
+                                    readModelType, ApplyAsyncMethodName, methodSignature);
+                            return new ApplyMethod(method);
+                        }
+
+                        return null;
+                    });
 
                 if (applyMethod != null)
                 {
-                    applyMethod(readModel, readModelContext, domainEvent);
+                    await applyMethod.Apply(readModel, readModelContext, domainEvent);
                     appliedAny = true;
                 }
             }
 
-            return Task.FromResult(appliedAny);
+            return appliedAny;
+        }
+
+        private class ApplyMethod
+        {
+            private readonly Func<IReadModel, IReadModelContext, IDomainEvent, Task> _asyncMethod;
+            private readonly Action<IReadModel, IReadModelContext, IDomainEvent> _syncMethod;
+
+            public ApplyMethod(Action<IReadModel, IReadModelContext, IDomainEvent> syncMethod)
+            {
+                _syncMethod = syncMethod;
+            }
+
+            public ApplyMethod(Func<IReadModel, IReadModelContext, IDomainEvent, Task> asyncMethod)
+            {
+                _asyncMethod = asyncMethod;
+            }
+
+            public Task Apply(IReadModel readModel, IReadModelContext context, IDomainEvent domainEvent)
+            {
+                if (_asyncMethod != null)
+                {
+                    return _asyncMethod(readModel, context, domainEvent);
+                }
+
+                _syncMethod(readModel, context, domainEvent);
+                return Task.FromResult(true);
+            }
         }
     }
 }


### PR DESCRIPTION
This adds support for async read model updates #577:

```csharp
public class AsyncPingReadModel : IReadModel,
             IAmAsyncReadModelFor<ThingyAggregate, ThingyId, ThingyPingEvent>
{
    public async Task ApplyAsync(IReadModelContext context, IDomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent> domainEvent)
    {
        await Task.Delay(50);
        PingEventsReceived = true;
    }
...
```

You can mix and match asynchronous and synchronous updates, as long as you don't subscribe to the same event in both ways.