### PR TITLE
throw on failed saga command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,27 @@
 * Fix: `Identity<T>.NewComb()` now produces string values that doesn't cause
   too much index fragmentation in MSSQL string columns
 
+* Breaking: Commands published from AggregateSaga which return `false` 
+  in `IExecutionResult.IsSuccess` will newly lead to an exception being thrown.
+  For disabling all new changes just set protected property
+  `AggregateSaga.ThrowExceptionsOnFailedPublish` to `false` in your AggregateSaga constructor.
+  Also an Exception thrown from any command won't prevent other commands from being executed.
+  All exceptions will be collected and then re-thrown in AggregateException (even in case 
+  of just one Exception). The exception structure is following:
+  - SagaPublishException : AggregateException
+    - .InnerExceptions
+      - CommandException : Exception
+        - .CommandType
+        - .SourceId
+        - .InnerException # in case of an exception thrown from the command
+      - CommandException : Exception
+        - .CommandType
+        - .SourceId
+        - .ExecutionResult # in case of returned `false` in `IExecutionResult.IsSuccess`
+  You need to update your `ISagaErrorHandler` implementation to reflect new exception structure,
+  unless you disable this new feature.
+
+
 ### New in 0.69.3772 (released 2019-02-12)
 
 * New: Added configuration option to set the "point of no return" when using

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,24 @@
 ### New in 0.71 (not released yet)
 
-* _Nothing yet_
+* Breaking: Commands published from AggregateSaga which return `false` 
+  in `IExecutionResult.IsSuccess` will newly lead to an exception being thrown.
+  For disabling all new changes just set protected property
+  `AggregateSaga.ThrowExceptionsOnFailedPublish` to `false` in your AggregateSaga constructor.
+  Also an Exception thrown from any command won't prevent other commands from being executed.
+  All exceptions will be collected and then re-thrown in SagaPublishException (even in case 
+  of just one Exception). The exception structure is following:
+  - SagaPublishException : AggregateException
+    - .InnerExceptions
+      - CommandException : Exception
+        - .CommandType
+        - .SourceId
+        - .InnerException # in case of an exception thrown from the command
+      - CommandException : Exception
+        - .CommandType
+        - .SourceId
+        - .ExecutionResult # in case of returned `false` in `IExecutionResult.IsSuccess`
+  You need to update your `ISagaErrorHandler` implementation to reflect new exception structure,
+  unless you disable this new feature.
 
 ### New in 0.70.3824 (released 2019-04-11)
 
@@ -26,27 +44,6 @@
   for delivery of external event to AggregateSaga
 * Fix: `Identity<T>.NewComb()` now produces string values that doesn't cause
   too much index fragmentation in MSSQL string columns
-
-* Breaking: Commands published from AggregateSaga which return `false` 
-  in `IExecutionResult.IsSuccess` will newly lead to an exception being thrown.
-  For disabling all new changes just set protected property
-  `AggregateSaga.ThrowExceptionsOnFailedPublish` to `false` in your AggregateSaga constructor.
-  Also an Exception thrown from any command won't prevent other commands from being executed.
-  All exceptions will be collected and then re-thrown in AggregateException (even in case 
-  of just one Exception). The exception structure is following:
-  - SagaPublishException : AggregateException
-    - .InnerExceptions
-      - CommandException : Exception
-        - .CommandType
-        - .SourceId
-        - .InnerException # in case of an exception thrown from the command
-      - CommandException : Exception
-        - .CommandType
-        - .SourceId
-        - .ExecutionResult # in case of returned `false` in `IExecutionResult.IsSuccess`
-  You need to update your `ISagaErrorHandler` implementation to reflect new exception structure,
-  unless you disable this new feature.
-
 
 ### New in 0.69.3772 (released 2019-02-12)
 

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,21 +1,326 @@
-﻿using EventFlow.Sagas.AggregateSagas;
+﻿using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using EventFlow.Exceptions;
+using EventFlow.Sagas;
 using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Commands;
+using EventFlow.TestHelpers.Aggregates.Events;
 using EventFlow.TestHelpers.Aggregates.Sagas;
+using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EventFlow.Tests.UnitTests.Sagas.AggregateSagas
 {
     [Category(Categories.Unit)]
-    public class AggregateSagaTests: TestsFor<ThingySaga>
+    public class AggregateSagaTests : TestsFor<ThingySaga>
     {
-        [Test]
-        public async Task AggregateSaga_Publish()
+        private ThingySagaId _thingySagaId;
+        private Mock<ICommandBus> _commandBus;
+        private Mock<ISagaContext> _sagaContext;
+
+        [SetUp]
+        public async Task SetUp()
         {
+            _thingySagaId = A<ThingySagaId>();
+            _commandBus = InjectMock<ICommandBus>();
+            _sagaContext = InjectMock<ISagaContext>();
+
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingySagaStartRequestedEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_ExecutionResultIsSuccessTrueDoesNotThrow()
+        {
+            // Arrange
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(ExecutionResult.Success()));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().BeNull();
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_ExecutionResultIsNullDoesNotThrow()
+        {
+            // Arrange
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult<IExecutionResult>(null));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().BeNull();
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_ExecutionResultIsSuccessFalseDisableThrow()
+        {
+            // Arrange
+            Sut.GetType()
+                .GetProperty("ThrowExceptionsOnFailedPublish", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.SetProperty)
+                .SetValue(Sut, false);
+            var message = Guid.NewGuid().ToString();
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(ExecutionResult.Failed(message)));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().BeNull();
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_ExecutionResultIsSuccessFalseThrows()
+        {
+            // Arrange
+            var message = Guid.NewGuid().ToString();
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(ExecutionResult.Failed(message)));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().NotBeNull();
+            exception.Should().BeAssignableTo<SagaPublishException>();
+            var sagaPublishException = exception as SagaPublishException;
+            sagaPublishException.InnerExceptions.Count.Should().Be(1);
+            var innerException = sagaPublishException.InnerExceptions[0];
+            innerException.Should().BeAssignableTo<CommandException>();
+            var commandException = innerException as CommandException;
+            commandException.Message.Should().Contain(message);
+            commandException.Message.Should().Contain(Sut.Id.ToString());
+            commandException.CommandType.Should().Be(typeof(ThingyAddMessageCommand));
+            commandException.ExecutionResult.Should().NotBeNull();
+            commandException.ExecutionResult.IsSuccess.Should().BeFalse();
+            commandException.ExecutionResult.ToString().Should().Contain(message);
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_ExecutionResultIsSuccessFalseThrowsTwice()
+        {
+            // Arrange
+            var message = Guid.NewGuid().ToString();
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(ExecutionResult.Failed(message)));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().NotBeNull();
+            exception.Should().BeAssignableTo<SagaPublishException>();
+            var sagaPublishException = exception as SagaPublishException;
+            sagaPublishException.InnerExceptions.Count.Should().Be(2);
+            foreach (var innerException in sagaPublishException.InnerExceptions)
+            {
+                innerException.Should().BeAssignableTo<CommandException>();
+                var commandException = innerException as CommandException;
+                commandException.Message.Should().Contain(message);
+                commandException.Message.Should().Contain(Sut.Id.ToString());
+                commandException.CommandType.Should().Be(typeof(ThingyAddMessageCommand));
+                commandException.ExecutionResult.Should().NotBeNull();
+                commandException.ExecutionResult.IsSuccess.Should().BeFalse();
+                commandException.ExecutionResult.ToString().Should().Contain(message);
+            }
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_ExceptionIsWrapped()
+        {
+            // Arrange
+            var message = Guid.NewGuid().ToString();
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => throw new ApplicationException(message));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().NotBeNull();
+            exception.Should().BeAssignableTo<SagaPublishException>();
+            var sagaPublishException = exception as SagaPublishException;
+            sagaPublishException.InnerExceptions.Count.Should().Be(1);
+            var innerException = sagaPublishException.InnerExceptions[0];
+            innerException.Should().BeAssignableTo<CommandException>();
+            var commandException = innerException as CommandException;
+            commandException.Message.Should().Contain(message);
+            commandException.Message.Should().Contain(Sut.Id.ToString());
+            commandException.CommandType.Should().Be(typeof(ThingyAddMessageCommand));
+            commandException.InnerException.Should().NotBeNull();
+            commandException.InnerException.Should().BeAssignableTo<ApplicationException>();
+            commandException.InnerException.Message.Should().Be(message);
+        }
+
+        [Test]
+        public async Task AggregateSaga_PublishAsync_TwoExceptionsAreWrapped()
+        {
+            // Arrange
+            var message = Guid.NewGuid().ToString();
+            _commandBus.Setup(
+                a => a.PublishAsync(
+                    It.IsAny<ICommand<ThingyAggregate, ThingyId, IExecutionResult>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => throw new ApplicationException(message));
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            await Sut.HandleAsync(
+                A<DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>>(),
+                _sagaContext.Object,
+                CancellationToken.None);
+            var exception = (Exception)null;
+
+            // Act
+            try
+            {
+                await Sut.PublishAsync(
+                    _commandBus.Object,
+                    CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            // Assert
+            exception.Should().NotBeNull();
+            exception.Should().BeAssignableTo<SagaPublishException>();
+            var sagaPublishException = exception as SagaPublishException;
+            sagaPublishException.InnerExceptions.Count.Should().Be(2);
+            foreach (var innerException in sagaPublishException.InnerExceptions)
+            {
+                innerException.Should().BeAssignableTo<CommandException>();
+                var commandException = innerException as CommandException;
+                commandException.Message.Should().Contain(message);
+                commandException.Message.Should().Contain(Sut.Id.ToString());
+                commandException.CommandType.Should().Be(typeof(ThingyAddMessageCommand));
+                commandException.InnerException.Should().NotBeNull();
+                commandException.InnerException.Should().BeAssignableTo<ApplicationException>();
+                commandException.InnerException.Message.Should().Be(message);
+            }
         }
     }
 }

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,0 +1,21 @@
+﻿using EventFlow.Sagas.AggregateSagas;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates.Sagas;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Tests.UnitTests.Sagas.AggregateSagas
+{
+    [Category(Categories.Unit)]
+    public class AggregateSagaTests: TestsFor<ThingySaga>
+    {
+        [Test]
+        public async Task AggregateSaga_Publish()
+        {
+        }
+    }
+}

--- a/Source/EventFlow/Exceptions/CommandAggregateException.cs
+++ b/Source/EventFlow/Exceptions/CommandAggregateException.cs
@@ -21,40 +21,45 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using EventFlow.Aggregates.ExecutionResults;
 using System;
+using System.Collections.Generic;
 
 namespace EventFlow.Exceptions
 {
-    public class CommandException : Exception
+    public class CommandAggregateException : AggregateException
     {
-        public Type CommandType { get; }
-        public IExecutionResult ExecutionResult { get; }
+        public CommandAggregateException()
+        {
+        }
 
-        public CommandException(Type commandType, string message)
+        public CommandAggregateException(IEnumerable<Exception> innerExceptions)
+            : base(innerExceptions)
+        {
+        }
+
+        public CommandAggregateException(params Exception[] innerExceptions)
+            : base(innerExceptions)
+        {
+        }
+
+        public CommandAggregateException(string message)
             : base(message)
         {
-            CommandType = commandType;
         }
 
-        public CommandException(Type commandType, string message, Exception innerException)
+        public CommandAggregateException(string message, IEnumerable<Exception> innerExceptions)
+            : base(message, innerExceptions)
+        {
+        }
+
+        public CommandAggregateException(string message, Exception innerException)
             : base(message, innerException)
         {
-            CommandType = commandType;
         }
 
-        public CommandException(Type commandType, IExecutionResult executionResult, string message)
-            : base(message)
+        public CommandAggregateException(string message, params Exception[] innerExceptions)
+            : base(message, innerExceptions)
         {
-            CommandType = commandType;
-            ExecutionResult = executionResult;
-        }
-
-        public CommandException(Type commandType, IExecutionResult executionResult, string message, Exception innerException)
-            : base(message, innerException)
-        {
-            CommandType = commandType;
-            ExecutionResult = executionResult;
         }
     }
 }

--- a/Source/EventFlow/Exceptions/CommandException.cs
+++ b/Source/EventFlow/Exceptions/CommandException.cs
@@ -1,0 +1,62 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace EventFlow.Exceptions
+{
+    public class CommandException : Exception
+    {
+        public ICommand Command { get; }
+        public IExecutionResult ExecutionResult { get; }
+
+        public CommandException(ICommand command, string message)
+            : base(message)
+        {
+            Command = command;
+        }
+
+        public CommandException(ICommand command, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Command = command;
+        }
+
+        public CommandException(ICommand command, IExecutionResult executionResult, string message)
+            : base(message)
+        {
+            Command = command;
+            ExecutionResult = executionResult;
+        }
+
+        public CommandException(ICommand command, IExecutionResult executionResult, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Command = command;
+            ExecutionResult = executionResult;
+        }
+    }
+}

--- a/Source/EventFlow/Exceptions/CommandException.cs
+++ b/Source/EventFlow/Exceptions/CommandException.cs
@@ -22,6 +22,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Core;
 using System;
 
 namespace EventFlow.Exceptions
@@ -29,32 +30,37 @@ namespace EventFlow.Exceptions
     public class CommandException : Exception
     {
         public Type CommandType { get; }
+        public ISourceId SourceId { get; }
         public IExecutionResult ExecutionResult { get; }
 
-        public CommandException(Type commandType, string message)
+        public CommandException(Type commandType, ISourceId sourceId, string message)
             : base(message)
         {
             CommandType = commandType;
+            SourceId = sourceId;
         }
 
-        public CommandException(Type commandType, string message, Exception innerException)
+        public CommandException(Type commandType, ISourceId sourceId, string message, Exception innerException)
             : base(message, innerException)
         {
             CommandType = commandType;
+            SourceId = sourceId;
         }
 
-        public CommandException(Type commandType, IExecutionResult executionResult, string message)
+        public CommandException(Type commandType, ISourceId sourceId, IExecutionResult executionResult, string message)
             : base(message)
         {
             CommandType = commandType;
             ExecutionResult = executionResult;
+            SourceId = sourceId;
         }
 
-        public CommandException(Type commandType, IExecutionResult executionResult, string message, Exception innerException)
+        public CommandException(Type commandType, ISourceId sourceId, IExecutionResult executionResult, string message, Exception innerException)
             : base(message, innerException)
         {
             CommandType = commandType;
             ExecutionResult = executionResult;
+            SourceId = sourceId;
         }
     }
 }

--- a/Source/EventFlow/Exceptions/SagaPublishException.cs
+++ b/Source/EventFlow/Exceptions/SagaPublishException.cs
@@ -26,38 +26,38 @@ using System.Collections.Generic;
 
 namespace EventFlow.Exceptions
 {
-    public class CommandAggregateException : AggregateException
+    public class SagaPublishException : AggregateException
     {
-        public CommandAggregateException()
+        public SagaPublishException()
         {
         }
 
-        public CommandAggregateException(IEnumerable<Exception> innerExceptions)
+        public SagaPublishException(IEnumerable<Exception> innerExceptions)
             : base(innerExceptions)
         {
         }
 
-        public CommandAggregateException(params Exception[] innerExceptions)
+        public SagaPublishException(params Exception[] innerExceptions)
             : base(innerExceptions)
         {
         }
 
-        public CommandAggregateException(string message)
+        public SagaPublishException(string message)
             : base(message)
         {
         }
 
-        public CommandAggregateException(string message, IEnumerable<Exception> innerExceptions)
+        public SagaPublishException(string message, IEnumerable<Exception> innerExceptions)
             : base(message, innerExceptions)
         {
         }
 
-        public CommandAggregateException(string message, Exception innerException)
+        public SagaPublishException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
-        public CommandAggregateException(string message, params Exception[] innerExceptions)
+        public SagaPublishException(string message, params Exception[] innerExceptions)
             : base(message, innerExceptions)
         {
         }

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -116,7 +116,7 @@ namespace EventFlow.Sagas.AggregateSagas
             if (ThrowExceptionsOnFailedPublish
                     && 0 < exceptions.Count)
             {
-                new CommandAggregateException(
+                new SagaPublishException(
                     $"Some commands published from a saga with ID '{Id}' failed. See InnerExceptions.",
                     exceptions);
             }

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -44,7 +44,7 @@ namespace EventFlow.Sagas.AggregateSagas
 
         private bool _isCompleted;
 
-        protected bool ThrowExceptionsOnFailedPublish { get; set; } = true;
+        protected virtual bool ThrowExceptionsOnFailedPublish { get; set; } = true;
 
         protected AggregateSaga(TIdentity id) : base(id)
         {

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -88,6 +88,7 @@ namespace EventFlow.Sagas.AggregateSagas
                         exceptions.Add(
                             new CommandException(
                                 command.GetType(),
+                                command.GetSourceId(),
                                 executionResult,
                                 $"Command '{command.GetType().PrettyPrint()}' with ID '{command.GetSourceId()}' published from a saga with ID '{Id}' failed with: '{executionResult}'. See ExecutionResult."));
                     }
@@ -97,7 +98,8 @@ namespace EventFlow.Sagas.AggregateSagas
                     exceptions.Add(
                         new CommandException(
                             command.GetType(),
-                            $"Command '{command.GetType().PrettyPrint()}' with ID '{command.GetSourceId()}' published from a saga with ID '{Id}' failed. See InnerException.",
+                            command.GetSourceId(),
+                            $"Command '{command.GetType().PrettyPrint()}' with ID '{command.GetSourceId()}' published from a saga with ID '{Id}' failed with: '{e.Message}'. See InnerException.",
                             e));
                 }
             }

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -116,7 +116,7 @@ namespace EventFlow.Sagas.AggregateSagas
             if (ThrowExceptionsOnFailedPublish
                     && 0 < exceptions.Count)
             {
-                new SagaPublishException(
+                throw new SagaPublishException(
                     $"Some commands published from a saga with ID '{Id}' failed. See InnerExceptions.",
                     exceptions);
             }

--- a/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
+++ b/Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs
@@ -113,8 +113,7 @@ namespace EventFlow.Sagas.AggregateSagas
                 }
             }
 
-            if (ThrowExceptionsOnFailedPublish
-                    && 0 < exceptions.Count)
+            if (0 < exceptions.Count)
             {
                 throw new SagaPublishException(
                     $"Some commands published from a saga with ID '{Id}' failed. See InnerExceptions.",


### PR DESCRIPTION
I changed branch, issue #599 , original comment:
@rasmus requested changes on this pull request.

Thanks for the fix! Just a few comments

Add { } for if statements
Write a few tests to make sure it doesn't break at some point in the future
Update release notes
As this is a change in behaivor, we need to supply some method of disabling it. It might be a protected property named ThrowExceptionsOnFailedPublish which a default value of true
In Source/EventFlow/Sagas/AggregateSagas/AggregateSaga.cs:

>              }
+
+            if (0 < fails.Count)
+                if (1 == fails.Count)
+                    throw DomainError.With(fails[0].ToString());
I would really like to see the failed execution results added to the exception. That way developers get more information on what went wrong and don't need to rely on .ToString() on their executions results.