### PR TITLE
EF-605: use EventId as SourceId for external event delivered to saga …

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,10 +18,8 @@
   - `EventFlow.Sql`
   - `EventFlow.SQLite`
 * New: Added [SourceLink](https://github.com/dotnet/sourcelink) support
-
-  * Fix: `DispatchToSagas.ProcessSagaAsync` use `EventId` instead of `SourceId` as `SourceId` 
+* Fix: `DispatchToSagas.ProcessSagaAsync` use `EventId` instead of `SourceId` as `SourceId` 
   for delivery of external event to AggregateSaga
-
 
 ### New in 0.69.3772 (released 2019-02-12)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,10 @@
   to .NET 4.5.2 as required by `AutoFixture.AutoMoq` NuGet dependency and to align packages on the
   [latest supported release](https://github.com/Microsoft/dotnet/blob/master/releases/README.md).
 
+  * Fix: `DispatchToSagas.ProcessSagaAsync` use `EventId` instead of `SourceId` as `SourceId` 
+  for delivery of external event to AggregateSaga
+
+
 ### New in 0.69.3772 (released 2019-02-12)
 
 * New: Added configuration option to set the "point of no return" when using

--- a/Source/EventFlow.TestHelpers/Test.cs
+++ b/Source/EventFlow.TestHelpers/Test.cs
@@ -120,6 +120,7 @@ namespace EventFlow.TestHelpers
                 {
                     Timestamp = A<DateTimeOffset>(),
                     SourceId = A<SourceId>(),
+                    EventId = A<EventId>(),
                 };
 
             if (aggregateSequenceNumber == 0)

--- a/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/DispatchToSagasTests.cs
@@ -92,6 +92,23 @@ namespace EventFlow.Tests.UnitTests.Sagas
         }
 
         [Test]
+        public async Task SagaStoreReceivesEventIdAsSourceId()
+        {
+            // Arrange
+            var sagaMock = Arrange_Woking_SagaStore(SagaState.Running);
+            var domainEvent = ADomainEvent<ThingyPingEvent>();
+
+            // Act
+            await Sut.ProcessAsync(new[] { domainEvent }, CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            _sagaStoreMock.Verify(a => a.UpdateAsync(It.IsAny<ISagaId>(), It.IsAny<Type>(),
+                domainEvent.Metadata.EventId,
+                It.IsAny<Func<ISaga, CancellationToken, Task>>(),
+                It.IsAny<CancellationToken>()));
+        }
+
+        [Test]
         public async Task SagaErrorHandlerIsInvokedCorrectly()
         {
             // Arrange

--- a/Source/EventFlow/Sagas/DispatchToSagas.cs
+++ b/Source/EventFlow/Sagas/DispatchToSagas.cs
@@ -104,7 +104,7 @@ namespace EventFlow.Sagas
                 await _sagaStore.UpdateAsync(
                     sagaId,
                     details.SagaType,
-                    domainEvent.Metadata.SourceId,
+                    domainEvent.Metadata.EventId,
                     (s, c) => UpdateSagaAsync(s, domainEvent, details, c),
                     cancellationToken)
                     .ConfigureAwait(false);


### PR DESCRIPTION
use EventId as SourceId for external event delivered to saga instead of event.SourceId