### PR TITLE
Fix: MsSqlEventPersistence with non-ANSI unicode characters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### New in 0.72 (not released yet)
 
-* _Nothing yet_
+* Fix: Storing events in MS SQL Server using `MsSqlEventPersistence` now correctly
+  handles non-ANSI unicode characters in strings.
 
 ### New in 0.71.3834 (released 2019-04-17)
 

--- a/Source/EventFlow.MsSql/Integrations/TableParameter.cs
+++ b/Source/EventFlow.MsSql/Integrations/TableParameter.cs
@@ -44,7 +44,7 @@ namespace EventFlow.MsSql.Integrations
         // The PropertyInfos and SqlMetaDatas static fields are dependent on the TRow type
         private static readonly Dictionary<SqlDbType, Action<SqlDataRecord, int, object>> SqlDataRecordSetters = new Dictionary<SqlDbType, Action<SqlDataRecord, int, object>>
             {
-                {SqlDbType.Text, (r, i, o) => r.SetString(i, (string)o)},
+                {SqlDbType.NText, (r, i, o) => r.SetString(i, (string)o)},
                 {SqlDbType.DateTimeOffset, (r, i, o) => r.SetDateTimeOffset(i, (DateTimeOffset)o)},
                 {SqlDbType.Int, (r, i, o) => r.SetInt32(i, (int)o)},
                 {SqlDbType.BigInt, (r, i, o) => r.SetInt64(i, (long)o)},
@@ -54,7 +54,7 @@ namespace EventFlow.MsSql.Integrations
             {
                 {typeof(Guid), SqlDbType.UniqueIdentifier},
                 {typeof(int), SqlDbType.Int},
-                {typeof(string), SqlDbType.Text},
+                {typeof(string), SqlDbType.NText},
                 {typeof(long), SqlDbType.BigInt},
                 {typeof(DateTime), SqlDbType.DateTime},
                 {typeof(DateTimeOffset), SqlDbType.DateTimeOffset},

--- a/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
+++ b/Source/EventFlow.TestHelpers/Suites/TestSuiteForEventStore.cs
@@ -35,6 +35,7 @@ using EventFlow.Extensions;
 using EventFlow.Subscribers;
 using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Commands;
+using EventFlow.TestHelpers.Aggregates.Entities;
 using EventFlow.TestHelpers.Aggregates.Events;
 using EventFlow.TestHelpers.Aggregates.ValueObjects;
 using EventFlow.TestHelpers.Extensions;
@@ -101,6 +102,24 @@ namespace EventFlow.TestHelpers.Suites
             loadedTestAggregate.IsNew.Should().BeFalse();
             loadedTestAggregate.Version.Should().Be(1);
             loadedTestAggregate.PingsReceived.Count.Should().Be(1);
+        }
+
+        [Test]
+        public async Task EventsCanContainUnicodeCharacters()
+        {
+            // Arrange
+            var id = ThingyId.New;
+            var testAggregate = await LoadAggregateAsync(id).ConfigureAwait(false);
+            var message = new ThingyMessage(ThingyMessageId.New, "😉");
+
+            testAggregate.AddMessage(message);
+            await testAggregate.CommitAsync(EventStore, SnapshotStore, SourceId.New, CancellationToken.None).ConfigureAwait(false);
+
+            // Act
+            var loadedTestAggregate = await LoadAggregateAsync(id).ConfigureAwait(false);
+
+            // Assert
+            loadedTestAggregate.Messages.Single().Message.Should().Be("😉");
         }
 
         [Test]


### PR DESCRIPTION
Fixes #636

`TableParameter` class used `SqlDbType.Text` instead of `SqlDbType.NText`:

    /// <summary>
    /// <see cref="T:System.String" />. A variable-length stream of non-Unicode data with a maximum length of 2 31 -1 (or 2,147,483,647) characters.</summary>
    Text = 18, // 0x00000012

    /// <summary>
    /// <see cref="T:System.String" />. A variable-length stream of Unicode data with a maximum length of 2 30 - 1 (or 1,073,741,823) characters.</summary>
    NText = 11, // 0x0000000B

Now, this change could somehow break existing events, affect performance and prevent storing large events. Should we add a compatibility switch?