### PR TITLE
Publishing symbols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ skip_tags: true
 build_script:
   - cmd: powershell -NoProfile -ExecutionPolicy unrestricted -Command ".\up_integration-test-env.ps1; .\build.ps1 -Target All;"
 
-image: Visual Studio 2017
+image: Visual Studio 2019 Preview
 
 environment:
   HELPZ_POSTGRESQL_PASS: Password12!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ deploy:
     api_key:
       secure: +YlrKmWps7RJVPU4s7B4HWNL9cZXaUVdiNJInli9IZPlTP+J0CyHsUvcDY8haE+b
     skip_symbols: false
+    artifact: /.*\.(nupkg|snupkg)/
     on:
       branch: master
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 test: off
 
 artifacts:
-  - path: Build\Packages\*.nupkg
+  - path: Build\Packages\*nupkg
 
 services:
   - mssql2014

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ skip_tags: true
 build_script:
   - cmd: powershell -NoProfile -ExecutionPolicy unrestricted -Command ".\up_integration-test-env.ps1; .\build.ps1 -Target All;"
 
-image: Visual Studio 2019 Preview
+image: Visual Studio 2017
 
 environment:
   HELPZ_POSTGRESQL_PASS: Password12!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ deploy:
     on:
       branch: master
   - provider: GitHub
-    artifact: /.*\.(nupkg|zip)/
+    artifact: /.*\.(nupkg|zip|snupkg)/
     auth_token:
       secure: f+y+RL1ETsxIbYKlliZrmXpfr1wvEVNhGGEOYyl2K8ryz02WxXL+kLe7pu53Kc8r
     tag: v$(appveyor_build_version)


### PR DESCRIPTION
AppVeyor doesn't pick up `.snupkg` files according to https://github.com/appveyor/ci/issues/2753.

Documentation here: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

EventFlow correctly builds the packages after #638