### PR TITLE
JSON serialization config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 ### New in 0.72 (not released yet)
 
+* New: Configure JSON serialization: 
+  ```csharp
+  EventFlowOptions.New.
+    .ConfigureJson(json => json
+      .AddSingleValueObjects()
+      .AddConverter<SomeConverter>()
+    )
+  ```
 * New: `EventFlow.TestHelpers` are now released as .NET Standard as well
 * Fix: Upgrade `EventStore.Client` to v5.0.1 and use it for both .NET Framework and .NET Core
 * Fix: Storing events in MS SQL Server using `MsSqlEventPersistence` now correctly

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
@@ -1,0 +1,69 @@
+﻿using EventFlow.Configuration.Serialization;
+using EventFlow.Extensions;
+using EventFlow.TestHelpers;
+using EventFlow.ValueObjects;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Tests.UnitTests.Configuration.Serialization
+{
+    [Category(Categories.Unit)]
+    public class JsonOptionsTests
+    {
+        private class MyClass
+        {
+            public DateTime DateTime { get; set; }
+        }
+
+        private class MyClassConverter : JsonConverter<MyClass>
+        {
+            public override MyClass ReadJson(JsonReader reader, Type objectType, MyClass existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                return new MyClass() { DateTime = new DateTime((long)reader.Value) };
+            }
+
+            public override void WriteJson(JsonWriter writer, MyClass value, JsonSerializer serializer)
+            {
+                serializer.Serialize(writer, value.DateTime.Ticks);
+            }
+        }
+
+        private class MySingleValueObject : SingleValueObject<DateTime>
+        {
+            public MySingleValueObject(DateTime value) : base(value) { }
+        }
+
+
+        [Test]
+        public void JsonOptionsCanBeUsedToConstructJsonSerializerSettings()
+        {
+            // Arrange
+            var jsonOptions = JsonOptions.New
+                .Use(() => new JsonSerializerSettings())
+                .AddConverter<MyClassConverter>();
+
+            var someJsonSerializerSettings = new JsonSerializerSettings();
+            jsonOptions.Apply(someJsonSerializerSettings);
+            JsonConvert.DefaultSettings = () => someJsonSerializerSettings;
+
+            // Act
+            var myClassSerialized = JsonConvert.SerializeObject(new MyClass() { DateTime = new DateTime(1000000) });
+            var myClassDeserialized = JsonConvert.DeserializeObject<MyClass>(myClassSerialized);
+            var svoSerialized = JsonConvert.SerializeObject(new MySingleValueObject(new DateTime(1970, 1, 1)));
+            var svoDeserialized = JsonConvert.DeserializeObject<MySingleValueObject>(svoSerialized);
+
+            // Assert
+            myClassSerialized.Should().Be("1000000");
+            myClassDeserialized.DateTime.Ticks.Should().Be(1000000);
+            myClassDeserialized.DateTime.Ticks.Should().NotBe(10);
+            svoDeserialized.Should().Be(new MySingleValueObject(new DateTime(1970, 1, 1)));
+            svoDeserialized.Should().NotBe(new MySingleValueObject(new DateTime(2001, 1, 1)));
+        }
+    }
+}

--- a/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
@@ -1,0 +1,69 @@
+﻿using EventFlow.Core;
+using EventFlow.Extensions;
+using EventFlow.TestHelpers;
+using EventFlow.ValueObjects;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventFlow.Tests.UnitTests.Extensions
+{
+    [Category(Categories.Unit)]
+    public class JsonSerializerExtensionTests
+    {
+        private class MyClass
+        {
+            public DateTime DateTime { get; set; }
+        }
+
+        private class MyClassConverter : JsonConverter<MyClass>
+        {
+            public override MyClass ReadJson(JsonReader reader, Type objectType, MyClass existingValue, bool hasExistingValue, Newtonsoft.Json.JsonSerializer serializer)
+            {
+                return new MyClass() { DateTime = new DateTime((long)reader.Value) };
+            }
+
+            public override void WriteJson(JsonWriter writer, MyClass value, Newtonsoft.Json.JsonSerializer serializer)
+            {
+                serializer.Serialize(writer, value.DateTime.Ticks);
+            }
+        }
+
+        private class MySingleValueObject : SingleValueObject<DateTime>
+        {
+            public MySingleValueObject(DateTime value) : base(value) { }
+        }
+
+
+        [Test]
+        public void JsonSerializerCanBeConfigured()
+        {
+            // Arrange
+            var resolver = EventFlowOptions.New
+                .ConfigureJson(json => json
+                    .AddSingleValueObjects()
+                    .AddConverter<MyClassConverter>()
+                )
+                .CreateResolver();
+            var serializer = resolver.Resolve<IJsonSerializer>();
+
+            // Act
+            var myClassSerialized = serializer.Serialize(new MyClass() { DateTime = new DateTime(1000000) });
+            var myClassDeserialized = serializer.Deserialize<MyClass>(myClassSerialized);
+            var svoSerialized = serializer.Serialize(new MySingleValueObject(new DateTime(1970, 1, 1)));
+            var svoDeserialized = serializer.Deserialize<MySingleValueObject>(svoSerialized);
+
+            // Assert
+            myClassSerialized.Should().Be("1000000");
+            myClassDeserialized.DateTime.Ticks.Should().Be(1000000);
+            myClassDeserialized.DateTime.Ticks.Should().NotBe(10);
+            svoDeserialized.Should().Be(new MySingleValueObject(new DateTime(1970, 1, 1)));
+            svoDeserialized.Should().NotBe(new MySingleValueObject(new DateTime(2001, 1, 1)));
+        }
+    }
+}

--- a/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/IJsonOptions.cs
@@ -21,40 +21,12 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using EventFlow.Configuration.Serialization;
 using Newtonsoft.Json;
 
-namespace EventFlow.Core
+namespace EventFlow.Configuration.Serialization
 {
-    public class JsonSerializer : IJsonSerializer
+    public interface IJsonOptions
     {
-        private readonly JsonSerializerSettings _settingsNotIndented = new JsonSerializerSettings();
-        private readonly JsonSerializerSettings _settingsIndented = new JsonSerializerSettings();
-
-        public JsonSerializer(IJsonOptions options = null)
-        {
-            options?.Apply(_settingsIndented);
-            options?.Apply(_settingsNotIndented);
-
-            _settingsIndented.Formatting = Formatting.Indented;
-            _settingsNotIndented.Formatting = Formatting.None;
-        }
-
-        public string Serialize(object obj, bool indented = false)
-        {
-            var settings = indented ? _settingsIndented : _settingsNotIndented;
-            return JsonConvert.SerializeObject(obj, settings);
-        }
-
-        public object Deserialize(string json, Type type)
-        {
-            return JsonConvert.DeserializeObject(json, type, _settingsNotIndented);
-        }
-
-        public T Deserialize<T>(string json)
-        {
-            return JsonConvert.DeserializeObject<T>(json, _settingsNotIndented);
-        }
+        void Apply(JsonSerializerSettings settings);
     }
 }

--- a/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
+++ b/Source/EventFlow/Configuration/Serialization/JsonOptions.cs
@@ -21,40 +21,16 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using EventFlow.Configuration.Serialization;
 using Newtonsoft.Json;
 
-namespace EventFlow.Core
+namespace EventFlow.Configuration.Serialization
 {
-    public class JsonSerializer : IJsonSerializer
+    public class JsonOptions : IJsonOptions
     {
-        private readonly JsonSerializerSettings _settingsNotIndented = new JsonSerializerSettings();
-        private readonly JsonSerializerSettings _settingsIndented = new JsonSerializerSettings();
-
-        public JsonSerializer(IJsonOptions options = null)
+        public void Apply(JsonSerializerSettings settings)
         {
-            options?.Apply(_settingsIndented);
-            options?.Apply(_settingsNotIndented);
-
-            _settingsIndented.Formatting = Formatting.Indented;
-            _settingsNotIndented.Formatting = Formatting.None;
         }
 
-        public string Serialize(object obj, bool indented = false)
-        {
-            var settings = indented ? _settingsIndented : _settingsNotIndented;
-            return JsonConvert.SerializeObject(obj, settings);
-        }
-
-        public object Deserialize(string json, Type type)
-        {
-            return JsonConvert.DeserializeObject(json, type, _settingsNotIndented);
-        }
-
-        public T Deserialize<T>(string json)
-        {
-            return JsonConvert.DeserializeObject<T>(json, _settingsNotIndented);
-        }
+        public static JsonOptions New => new JsonOptions();
     }
 }

--- a/Source/EventFlow/EventFlowOptions.cs
+++ b/Source/EventFlow/EventFlowOptions.cs
@@ -29,6 +29,7 @@ using EventFlow.Commands;
 using EventFlow.Configuration;
 using EventFlow.Configuration.Bootstraps;
 using EventFlow.Configuration.Cancellation;
+using EventFlow.Configuration.Serialization;
 using EventFlow.Core;
 using EventFlow.Core.Caching;
 using EventFlow.Core.IoC;
@@ -205,7 +206,8 @@ namespace EventFlow
             serviceRegistration.Register<IEventJsonSerializer, EventJsonSerializer>();
             serviceRegistration.Register<IEventDefinitionService, EventDefinitionService>(Lifetime.Singleton);
             serviceRegistration.Register<IQueryProcessor, QueryProcessor>();
-            serviceRegistration.Register<IJsonSerializer, JsonSerializer>();
+            serviceRegistration.Register<IJsonSerializer, JsonSerializer>(Lifetime.Singleton);
+            serviceRegistration.Register<IJsonOptions, JsonOptions>();
             serviceRegistration.Register<IJobScheduler, InstantJobScheduler>();
             serviceRegistration.Register<IJobRunner, JobRunner>();
             serviceRegistration.Register<IJobDefinitionService, JobDefinitionService>(Lifetime.Singleton);

--- a/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
+++ b/Source/EventFlow/Extensions/EventFlowOptionsJsonConfigurationExtensions.cs
@@ -23,38 +23,16 @@
 
 using System;
 using EventFlow.Configuration.Serialization;
-using Newtonsoft.Json;
 
-namespace EventFlow.Core
+namespace EventFlow.Extensions
 {
-    public class JsonSerializer : IJsonSerializer
+    public static class EventFlowOptionsJsonConfigurationExtensions
     {
-        private readonly JsonSerializerSettings _settingsNotIndented = new JsonSerializerSettings();
-        private readonly JsonSerializerSettings _settingsIndented = new JsonSerializerSettings();
-
-        public JsonSerializer(IJsonOptions options = null)
+        public static IEventFlowOptions ConfigureJson(this IEventFlowOptions options, Func<JsonOptions, IJsonOptions> configure)
         {
-            options?.Apply(_settingsIndented);
-            options?.Apply(_settingsNotIndented);
-
-            _settingsIndented.Formatting = Formatting.Indented;
-            _settingsNotIndented.Formatting = Formatting.None;
-        }
-
-        public string Serialize(object obj, bool indented = false)
-        {
-            var settings = indented ? _settingsIndented : _settingsNotIndented;
-            return JsonConvert.SerializeObject(obj, settings);
-        }
-
-        public object Deserialize(string json, Type type)
-        {
-            return JsonConvert.DeserializeObject(json, type, _settingsNotIndented);
-        }
-
-        public T Deserialize<T>(string json)
-        {
-            return JsonConvert.DeserializeObject<T>(json, _settingsNotIndented);
+            if (configure == null) throw new ArgumentNullException(nameof(configure));
+            var config = configure(JsonOptions.New);
+            return options.RegisterServices(s => s.Register(_ => config));
         }
     }
 }

--- a/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
+++ b/Source/EventFlow/Extensions/JsonOptionsExtensions.cs
@@ -1,0 +1,100 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+using EventFlow.Configuration.Serialization;
+using EventFlow.ValueObjects;
+using Newtonsoft.Json;
+
+namespace EventFlow.Extensions
+{
+    public static class JsonOptionsExtensions
+    {
+        public static IJsonOptions Configure(this IJsonOptions options, Action<JsonSerializerSettings> action)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+            return new ChainedJsonOptions(options, action);
+        }
+
+        public static ChainedJsonOptions Use(this JsonOptions options, Func<JsonSerializerSettings> settingsFactory)
+        {
+            return new ChainedJsonOptions(options, target =>
+            {
+                var source = settingsFactory();
+                source.CopyTo(target);
+            });
+        }
+
+        public static IJsonOptions AddSingleValueObjects(this IJsonOptions options)
+        {
+            return options.AddConverter<SingleValueObjectConverter>();
+        }
+
+        public static IJsonOptions AddConverter<T>(this IJsonOptions options)
+            where T : JsonConverter, new()
+        {
+            return options.Configure(s => s.Converters.Insert(0, new T()));
+        }
+
+        private static JsonSerializerSettings Clone(this JsonSerializerSettings settings)
+        {
+            var result = new JsonSerializerSettings();
+            settings.CopyTo(result);
+            return result;
+        }
+
+        private static void CopyTo(this JsonSerializerSettings settings, JsonSerializerSettings target)
+        {
+            target.CheckAdditionalContent = settings.CheckAdditionalContent;
+            target.ConstructorHandling = settings.ConstructorHandling;
+            target.Context = settings.Context;
+            target.ContractResolver = settings.ContractResolver;
+            target.Culture = settings.Culture;
+            target.DateFormatHandling = settings.DateFormatHandling;
+            target.DateFormatString = settings.DateFormatString;
+            target.DateParseHandling = settings.DateParseHandling;
+            target.DateTimeZoneHandling = settings.DateTimeZoneHandling;
+            target.DefaultValueHandling = settings.DefaultValueHandling;
+            target.EqualityComparer = settings.EqualityComparer;
+            target.Error = settings.Error;
+            target.FloatFormatHandling = settings.FloatFormatHandling;
+            target.FloatParseHandling = settings.FloatParseHandling;
+            target.Formatting = settings.Formatting;
+            target.MaxDepth = settings.MaxDepth;
+            target.MetadataPropertyHandling = settings.MetadataPropertyHandling;
+            target.MissingMemberHandling = settings.MissingMemberHandling;
+            target.NullValueHandling = settings.NullValueHandling;
+            target.ObjectCreationHandling = settings.ObjectCreationHandling;
+            target.PreserveReferencesHandling = settings.PreserveReferencesHandling;
+            target.ReferenceLoopHandling = settings.ReferenceLoopHandling;
+            target.ReferenceResolverProvider = settings.ReferenceResolverProvider;
+            target.SerializationBinder = settings.SerializationBinder;
+            target.StringEscapeHandling = settings.StringEscapeHandling;
+            target.TraceWriter = settings.TraceWriter;
+            target.TypeNameAssemblyFormatHandling = settings.TypeNameAssemblyFormatHandling;
+            target.TypeNameHandling = settings.TypeNameHandling;
+            target.Converters = settings.Converters.ToList();
+        }
+    }
+}


### PR DESCRIPTION
As @frankebersoll pointed out in his PR #588, JSON serialization is currently configurable only by applying attributes directly to classes or by overriding global `JsonConvert.JsonSerializerSettings`. Unfortunately his PR was never merged, so I've reapplied some of this work and added some tests. This PR will allow configuring JSON serialization through `EventFlowOptions`:
```csharp
EventFlowOptions.New
  .ConfigureJson(json => json
    .AddSingleValueObjects()
    .AddConverter<SomeConverter>()
  );
```