### PR TITLE
Make EventStore connection string configurable

### DIFF
--- a/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
@@ -81,10 +81,23 @@ namespace EventFlow.EventStores.EventStore.Extensions
             Uri uri,
             ConnectionSettings connectionSettings)
         {
+            return UseEventStoreEventStore(eventFlowOptions, uri, connectionSettings);
+        }
+
+        public static IEventFlowOptions UseEventStoreEventStore(
+            this IEventFlowOptions eventFlowOptions,
+            Uri uri,
+            ConnectionSettings connectionSettings,
+            string connectionNamePrefix)
+        {
+            var sanitizedConnectionNamePrefix = string.IsNullOrEmpty(connectionNamePrefix)
+                ? string.Empty
+                : connectionNamePrefix + " - ";
+
             var eventStoreConnection = EventStoreConnection.Create(
                 connectionSettings,
                 uri,
-                $"EventFlow v{typeof(EventFlowOptionsExtensions).Assembly.GetName().Version}");
+                $"{sanitizedConnectionNamePrefix}EventFlow v{typeof(EventFlowOptionsExtensions).Assembly.GetName().Version}");
 
             using (var a = AsyncHelper.Wait)
             {

--- a/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
+++ b/Source/EventFlow.EventStores.EventStore/Extensions/EventFlowOptionsExtensions.cs
@@ -70,25 +70,9 @@ namespace EventFlow.EventStores.EventStore.Extensions
 
         public static IEventFlowOptions UseEventStoreEventStore(
             this IEventFlowOptions eventFlowOptions,
-            Uri uri)
-        {
-            return eventFlowOptions
-                .UseEventStoreEventStore(uri, ConnectionSettings.Default);
-        }
-
-        public static IEventFlowOptions UseEventStoreEventStore(
-            this IEventFlowOptions eventFlowOptions,
-            Uri uri,
-            ConnectionSettings connectionSettings)
-        {
-            return UseEventStoreEventStore(eventFlowOptions, uri, connectionSettings);
-        }
-
-        public static IEventFlowOptions UseEventStoreEventStore(
-            this IEventFlowOptions eventFlowOptions,
             Uri uri,
             ConnectionSettings connectionSettings,
-            string connectionNamePrefix)
+            string connectionNamePrefix = null)
         {
             var sanitizedConnectionNamePrefix = string.IsNullOrEmpty(connectionNamePrefix)
                 ? string.Empty


### PR DESCRIPTION
We use multiple applications on the same event store instance. We want to differentiate between these different applications and a way to do this is to make each connection name recognizable by an unique name.

I therefore suggest a small change to the extension method, so we can prepend the current  connectionname (with eventflow and version) with a custom string.