### PR TITLE
Remove empty constructor requirement on mongo readmodels

### DIFF
--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -53,7 +53,7 @@ namespace EventFlow.MongoDB.Extensions
 
         public static IEventFlowOptions UseMongoDbReadModel<TReadModel>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IMongoDbReadModel, new()
+            where TReadModel : class, IMongoDbReadModel
         {
             return eventFlowOptions
                 .RegisterServices(f =>
@@ -66,7 +66,7 @@ namespace EventFlow.MongoDB.Extensions
 
         public static IEventFlowOptions UseMongoDbReadModel<TReadModel, TReadModelLocator>(
             this IEventFlowOptions eventFlowOptions)
-            where TReadModel : class, IMongoDbReadModel, new()
+            where TReadModel : class, IMongoDbReadModel
             where TReadModelLocator : IReadModelLocator
         {
             return eventFlowOptions

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -8,7 +8,7 @@ using MongoDB.Driver;
 namespace EventFlow.MongoDB.ReadStores
 {
 	public interface IMongoDbReadModelStore<TReadModel> : IReadModelStore<TReadModel>
-		where TReadModel : class, IReadModel, new()
+		where TReadModel : class, IReadModel
 	{
 		Task<IAsyncCursor<TReadModel>> FindAsync(
 			Expression<Func<TReadModel, bool>> filter,

--- a/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
@@ -17,7 +17,7 @@ using MongoDB.Driver;
 namespace EventFlow.MongoDB.ReadStores
 {
 	public class MongoDbReadModelStore<TReadModel> : IMongoDbReadModelStore<TReadModel>
-        where TReadModel : class, IMongoDbReadModel, new()
+        where TReadModel : class, IMongoDbReadModel
     {
         private readonly ILog _log;
         private readonly IMongoDatabase _mongoDatabase;


### PR DESCRIPTION
Changes already done with other db providers in #393 applied also to MongoDb.