### PR TITLE
Correct license header in accordance with CLA

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
-# Contributers
+# Contributors
 
-List of notable contributers to EventFlow sorted alphabetically. For a
+List of notable contributors to EventFlow sorted alphabetically. For a
 complete list of all contributions to EventFlow, have look at the
 [contributors](https://github.com/eventflow/EventFlow/graphs/contributors)
 graph.
@@ -18,6 +18,11 @@ If you think your name is missing from the list, create a pull-request.
 ### [Edward Wilson](https://github.com/edwardwilson)
 
 * Original MongoDB author
+
+### [Emanuele Curati](https://github.com/ProH4Ck)
+
+* ASP.NET Core 3 
+* Docker integration test cleanup
 
 ### [Frank Ebersoll](https://github.com/frankebersoll)
 
@@ -37,17 +42,17 @@ If you think your name is missing from the list, create a pull-request.
 * Several key contributions and bug fixes
 * Donated Navicat Essentials for SQLite
 
-### [janfeyen](https://github.com/janfeyen)
+### [Jan Feyen](https://github.com/janfeyen)
 
 * Key MongoDB contributions
-
-### [rmess](https://github.com/rmess)
-
-* PostgreSQL implementation
 
 ### [Rasmus Mikkelsen](https://github.com/rasmus)
 
 * Original creator and author of EventFlow
+
+### [Rida Messaoudene](https://github.com/rmess)
+
+* PostgreSQL implementation
 
 ### [Willem Peters](https://github.com/wgtmpeters)
 

--- a/Source/EventFlow.AspNetCore/EventFlow.AspNetCore.csproj
+++ b/Source/EventFlow.AspNetCore/EventFlow.AspNetCore.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.AspNetCore</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>AspNetCore support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing AspNetCore</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
+++ b/Source/EventFlow.Autofac/EventFlow.Autofac.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.Autofac</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Autofac support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing Autofac</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
@@ -1,3 +1,25 @@
-﻿using System.Runtime.CompilerServices;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("EventFlow.Autofac.Tests")]

--- a/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.Autofac/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/EventFlow.DependencyInjection.csproj
+++ b/Source/EventFlow.DependencyInjection/EventFlow.DependencyInjection.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.DependencyInjection</Title>
     <Authors>Frank Ebersoll</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Microsoft.Extensions.DependencyInjection support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing Microsoft.Extensions.DependencyInjection ServiceProvider ServiceCollection</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow.DependencyInjection/Properties/AssemblyInfo.cs
@@ -1,3 +1,25 @@
-﻿using System.Runtime.CompilerServices;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("EventFlow.ServiceProvider.Tests")]

--- a/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
+++ b/Source/EventFlow.Elasticsearch/EventFlow.Elasticsearch.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.Elasticsearch</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Elasticsearch support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing Elasticsearch</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.EntityFramework/EventFlow.EntityFramework.csproj
+++ b/Source/EventFlow.EntityFramework/EventFlow.EntityFramework.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.EntityFramework</Title>
     <Authors>Frank Ebersoll</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Entity Framework Core support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing EF Entity Framework Core</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.EventStores.EventStore/EventFlow.EventStores.EventStore.csproj
+++ b/Source/EventFlow.EventStores.EventStore/EventFlow.EventStores.EventStore.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.EventStores.EventStore</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Event Store event store for EventFlow. Download it from https://geteventstore.com/</Description>
     <PackageTags>CQRS ES event sourcing EventStore</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
+++ b/Source/EventFlow.Hangfire/EventFlow.Hangfire.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.Hangfire</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Hangfire job scheduling support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing Hangfire</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/EventStores/MongoDbEventStoreTests.cs
@@ -1,5 +1,25 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using EventFlow.Configuration;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Suites;

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
@@ -1,6 +1,7 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/Queries/MongoDbThingyGetWithLinqQuery.cs
@@ -1,7 +1,28 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using System.Linq;
 using EventFlow.MongoDB.Tests.IntegrationTests.ReadStores.ReadModels;
 using EventFlow.Queries;
-using EventFlow.TestHelpers.Aggregates;
 
 namespace EventFlow.MongoDB.Tests.IntegrationTests.ReadStores.Queries
 {

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
@@ -1,6 +1,7 @@
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/ReadStores/QueryHandlers/MongoDbThingyGetWithLinqQueryHandler.cs
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -5,7 +27,6 @@ using EventFlow.MongoDB.ReadStores;
 using EventFlow.MongoDB.Tests.IntegrationTests.ReadStores.Queries;
 using EventFlow.MongoDB.Tests.IntegrationTests.ReadStores.ReadModels;
 using EventFlow.Queries;
-using EventFlow.TestHelpers.Aggregates;
 
 namespace EventFlow.MongoDB.Tests.IntegrationTests.ReadStores.QueryHandlers
 {

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.MongoDB.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
+++ b/Source/EventFlow.MongoDB/EventFlow.MongoDB.csproj
@@ -8,8 +8,9 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Title>EventFlow.MongoDB</Title>
     <Authors>Jan Feyen, Warren Pieterse</Authors>
-    <Owners>Jan Feyen, Warren Pieterse</Owners>
-    <Copyright>Copyright (c) Jan Feyen/Warren Pieterse 2015 - 2017</Copyright>
+    <Owners>Rasmus Mikkelsen</Owners>
+    <Company>Rasmus Mikkelsen</Company>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>MongoDB ReadStore and Snapshot Persistence for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing MongoDB</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
@@ -1,8 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace EventFlow.MongoDB.EventStore
 {

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventPersistenceInitializer.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/IMongoDbEventSequenceStore.cs
@@ -1,4 +1,26 @@
-﻿namespace EventFlow.MongoDB.EventStore
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace EventFlow.MongoDB.EventStore
 {
     public interface IMongoDbEventSequenceStore
     {

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventPersistenceInitializer.cs
@@ -1,4 +1,25 @@
-﻿
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using EventFlow.MongoDB.ValueObjects;
 using MongoDB.Driver;
 

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
@@ -1,10 +1,30 @@
-﻿using EventFlow.MongoDB.ValueObjects;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.MongoDB.ValueObjects;
 using MongoDB.Driver;
 
 namespace EventFlow.MongoDB.EventStore
 {
-	using System.Threading;
-
 	public class MongoDbEventSequenceStore : IMongoDbEventSequenceStore
 	{
 		private const string _collectionName = "eventflow.counter";

--- a/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
+++ b/Source/EventFlow.MongoDB/EventStore/MongoDbEventSequenceStore.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsMongoDbEventStoreExtensions.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Extensions;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Extensions;
 using EventFlow.MongoDB.EventStore;
 
 namespace EventFlow.MongoDB.Extensions

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Extensions;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Extensions;
 using EventFlow.MongoDB.SnapshotStores;
 
 namespace EventFlow.MongoDB.Extensions

--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Configuration;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Configuration;
 using EventFlow.Extensions;
 using EventFlow.MongoDB.ReadStores;
 using EventFlow.ReadStores;

--- a/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
+++ b/Source/EventFlow.MongoDB/Extensions/MongoDbOptionsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 
 namespace EventFlow.MongoDB.ReadStores.Attributes
 {

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbCollectionNameAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 
 namespace EventFlow.MongoDB.ReadStores.Attributes
 {

--- a/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/Attributes/MongoDbGeoSpatialIndexAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModel.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.ReadStores;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.ReadStores;
 
 namespace EventFlow.MongoDB.ReadStores
 {

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IMongoDbReadModelStore.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.ReadStores;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.ReadStores;
 using System;
 using System.Linq.Expressions;
 using System.Threading;
@@ -14,7 +36,7 @@ namespace EventFlow.MongoDB.ReadStores
         Task<IAsyncCursor<TReadModel>> FindAsync(
             Expression<Func<TReadModel, bool>> filter,
             FindOptions<TReadModel, TReadModel> options = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         IQueryable<TReadModel> AsQueryable();
     }

--- a/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/IReadModelDescriptionProvider.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.MongoDB.ValueObjects;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.MongoDB.ValueObjects;
 
 namespace EventFlow.MongoDB.ReadStores
 {

--- a/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/MongoDbReadModelStore.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Extensions;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Extensions;
 using EventFlow.MongoDB.ReadStores.Attributes;
 using EventFlow.MongoDB.ValueObjects;
 using System;

--- a/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
+++ b/Source/EventFlow.MongoDB/ReadStores/ReadModelDescriptionProvider.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
+++ b/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
+++ b/Source/EventFlow.MongoDB/SnapshotStores/MongoDbSnapshotPersistence.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Core;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Core;
 using EventFlow.Extensions;
 using EventFlow.Logs;
 using EventFlow.MongoDB.ValueObjects;

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.ValueObjects;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.ValueObjects;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace EventFlow.MongoDB.ValueObjects

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbCounterDataModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbEventDataModel.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using EventFlow.EventStores;
 using EventFlow.ValueObjects;
 using MongoDB.Bson.Serialization.Attributes;

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/MongoDbSnapshotDataModel.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.ValueObjects;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.ValueObjects;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;

--- a/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.ValueObjects;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.ValueObjects;
 using System;
 using System.Collections.Generic;
 

--- a/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/ReadModelDescription.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.ValueObjects;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.ValueObjects;
 using System;
 
 namespace EventFlow.MongoDB.ValueObjects

--- a/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
+++ b/Source/EventFlow.MongoDB/ValueObjects/RootCollectionName.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
+++ b/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
+++ b/Source/EventFlow.MsSql.Tests/Extensions/MsSqlDatabaseExtensions.cs
@@ -1,4 +1,26 @@
-﻿using System.Collections.Generic;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
 using System.Linq;
 using Dapper;
 using EventFlow.TestHelpers.MsSql;

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
+++ b/Source/EventFlow.MsSql.Tests/IntegrationTests/IdentityIndexFragmentationTests.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Linq;
 using System.Threading;
 using EventFlow.Core;

--- a/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
+++ b/Source/EventFlow.MsSql/EventFlow.MsSql.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.MsSql</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>MSSQL support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing MSSQL</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.Owin/EventFlow.Owin.csproj
+++ b/Source/EventFlow.Owin/EventFlow.Owin.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.Owin</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>OWIN support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing OWIN</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,12 +22,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Linq;
-
 using EventFlow.PostgreSql.EventStores;
 using EventFlow.TestHelpers;
-
 using FluentAssertions;
-
 using NUnit.Framework;
 
 namespace EventFlow.PostgreSql.Tests.IntegrationTests.EventStores

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/EventFlowEventStoresPostgresSqlTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlEventStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -20,7 +21,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Threading.Tasks;
 using EventFlow.Configuration;
 using EventFlow.Extensions;
 using EventFlow.PostgreSql.Connections;
@@ -29,7 +29,6 @@ using EventFlow.PostgreSql.Extensions;
 using EventFlow.PostgreSql.TestsHelpers;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Suites;
-
 using NUnit.Framework;
 
 namespace EventFlow.PostgreSql.Tests.IntegrationTests.EventStores

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/EventStores/PostgresSqlScriptsTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,12 +22,10 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Linq;
-
 using EventFlow.Extensions;
 using EventFlow.PostgreSql.EventStores;
 using EventFlow.PostgreSql.TestsHelpers;
 using EventFlow.TestHelpers;
-
 using NUnit.Framework;
 
 namespace EventFlow.PostgreSql.Tests.IntegrationTests.EventStores

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/PostgresSqlReadModelStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-
 using EventFlow.Configuration;
 using EventFlow.Extensions;
 using EventFlow.PostgreSql.Connections;
@@ -33,7 +33,6 @@ using EventFlow.PostgreSql.TestsHelpers;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates.Entities;
 using EventFlow.TestHelpers.Suites;
-
 using NUnit.Framework;
 
 namespace EventFlow.PostgreSql.Tests.IntegrationTests.ReadStores

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetMessagesQueryHandler.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -24,7 +25,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using EventFlow.Core;
 using EventFlow.PostgreSql.Connections;
 using EventFlow.PostgreSql.Tests.IntegrationTests.ReadStores.ReadModels;

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetQueryHandler.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -23,7 +24,6 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using EventFlow.Core;
 using EventFlow.PostgreSql.Connections;
 using EventFlow.PostgreSql.Tests.IntegrationTests.ReadStores.ReadModels;

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/QueryHandlers/PostgresSqlThingyGetVersionQueryHandler.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -23,7 +24,6 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using EventFlow.Core;
 using EventFlow.PostgreSql.Connections;
 using EventFlow.PostgreSql.Tests.IntegrationTests.ReadStores.ReadModels;

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyMessageReadModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/ReadStores/ReadModels/PostgresSqlThingyReadModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.ComponentModel.DataAnnotations.Schema;
-
 using EventFlow.Aggregates;
 using EventFlow.PostgreSql.ReadStores;
 using EventFlow.ReadStores;

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/EventFlowSnapshotStoresPostgresSqlTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,12 +22,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Linq;
-
 using EventFlow.PostgreSql.SnapshotStores;
 using EventFlow.TestHelpers;
-
 using FluentAssertions;
-
 using NUnit.Framework;
 
 namespace EventFlow.PostgreSql.Tests.IntegrationTests.SnapshotStores

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
+++ b/Source/EventFlow.PostgreSql.Tests/IntegrationTests/SnapshotStores/PostgresSqlSnapshotStoreTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -28,7 +29,6 @@ using EventFlow.PostgreSql.SnapshotStores;
 using EventFlow.PostgreSql.TestsHelpers;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Suites;
-
 using NUnit.Framework;
 
 namespace EventFlow.PostgreSql.Tests.IntegrationTests.SnapshotStores

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/IPostgresSqlDatabase.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -24,7 +25,6 @@ using Npgsql;
 using System;
 
 namespace EventFlow.PostgreSql.TestsHelpers
-
 {
     public interface IPostgreSqlDatabase : IDisposable
     {

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 //
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/rasmus/Helpz
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlConnectionString.cs
@@ -1,18 +1,19 @@
 ﻿// The MIT License (MIT)
-//
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
-// https://github.com/rasmus/Helpz
-//
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-//
+// 
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgressSqlDatabase.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -24,7 +25,6 @@ using Npgsql;
 using System;
 
 namespace EventFlow.PostgreSql.TestsHelpers
-
 {
     public class PostgressSqlDatabase : IPostgreSqlDatabase
     {

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnection.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/IPostgresSqlConnectionFactory.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnection.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
+++ b/Source/EventFlow.PostgreSql/Connections/PostgresSqlConnectionFactory.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -23,7 +24,6 @@
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Npgsql;
 
 namespace EventFlow.PostgreSql.Connections

--- a/Source/EventFlow.PostgreSql/EventFlow.PostgreSql.csproj
+++ b/Source/EventFlow.PostgreSql/EventFlow.PostgreSql.csproj
@@ -8,8 +8,8 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Title>EventFlow.PostgreSql</Title>
     <Authors>Rida Messaoudene</Authors>
-    <Company>Rida Messaoudene</Company>
-    <Copyright>Copyright (c) Rida Messaoudene 2015 - 2018</Copyright>
+    <Company>Rasmus Mikkelsen</Company>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>POSTGRESQL support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing POSTGRESQL</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/EventFlowEventStoresPostgresSql.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,7 +23,6 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-
 using EventFlow.Sql.Extensions;
 using EventFlow.Sql.Migrations;
 

--- a/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
+++ b/Source/EventFlow.PostgreSql/EventStores/PostgresSqlEventPersistence.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -25,14 +26,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using EventFlow.Aggregates;
 using EventFlow.Core;
 using EventFlow.EventStores;
 using EventFlow.Exceptions;
 using EventFlow.Logs;
 using EventFlow.PostgreSql.Connections;
-
 using Npgsql;
 
 namespace EventFlow.PostgreSql.EventStores

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlEventStoreExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
-//
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsPostgresSqlReadStoreExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 //
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
+++ b/Source/EventFlow.PostgreSql/Extensions/EventFlowOptionsSnapshotExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/IPostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
+++ b/Source/EventFlow.PostgreSql/PostgresSqlDatabaseMigrator.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using DbUp.Builder;
-
 using EventFlow.Logs;
 using EventFlow.PostgreSql.Connections;
 using EventFlow.Sql.Migrations;

--- a/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
+++ b/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
+++ b/Source/EventFlow.PostgreSql/ReadModels/PostgresReadModelSqlGenerator.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Sql.ReadModels;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Sql.ReadModels;
 
 namespace EventFlow.PostgreSql.ReadModels
 {

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIdentityColumnAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-
 using EventFlow.Sql.ReadModels.Attributes;
 
 namespace EventFlow.PostgreSql.ReadStores.Attributes

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelIgnoreColumnAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-
 using EventFlow.Sql.ReadModels.Attributes;
 
 namespace EventFlow.PostgreSql.ReadStores.Attributes

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/Attributes/PostgresSqlReadModelVersionColumnAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-
 using EventFlow.Sql.ReadModels.Attributes;
 
 namespace EventFlow.PostgreSql.ReadStores.Attributes

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgresReadModelStore.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/IPostgressqlReadModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgresSqlReadModelStore.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
+++ b/Source/EventFlow.PostgreSql/ReadStores/PostgressqlReadModel.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,7 +22,6 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-
 using EventFlow.Extensions;
 using EventFlow.PostgreSql.ReadStores.Attributes;
 

--- a/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/IPostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,10 +22,8 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-
 using EventFlow.Core;
 using EventFlow.PostgreSql.Connections;
-
 using Npgsql;
 
 namespace EventFlow.PostgreSql.RetryStrategies

--- a/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
+++ b/Source/EventFlow.PostgreSql/RetryStrategies/PostgresSqlErrorRetryStrategy.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/EventFlowSnapshotStoresPostGresSql.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,7 +23,6 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-
 using EventFlow.Sql.Extensions;
 using EventFlow.Sql.Migrations;
 

--- a/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
@@ -1,6 +1,6 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rida Messaoudene
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
+++ b/Source/EventFlow.PostgreSql/SnapshotStores/PostgresSqlSnapshotPersistence.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,11 +22,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using EventFlow.Core;
 using EventFlow.Extensions;
 using EventFlow.Logs;

--- a/Source/EventFlow.RabbitMQ/EventFlow.RabbitMQ.csproj
+++ b/Source/EventFlow.RabbitMQ/EventFlow.RabbitMQ.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.RabbitMQ</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>RabbitMQ integration for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing RabbitMQ</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
+++ b/Source/EventFlow.SQLite/EventFlow.SQLite.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.SQLite</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>SQLite event store for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing SQLite</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.Sql/EventFlow.Sql.csproj
+++ b/Source/EventFlow.Sql/EventFlow.Sql.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.Sql</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>Generic SQL support for EventFlow</Description>
     <PackageTags>CQRS ES event sourcing SQL</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
+++ b/Source/EventFlow.TestHelpers/EventFlow.TestHelpers.csproj
@@ -9,7 +9,7 @@
     <Title>EventFlow.TestHelpers</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
     <Description>
       A collection of test helpers used to help develop event and read model stores for EventFlow. Please
       note that this is an alpha initial release of the test helpers package and content is subject

--- a/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
+++ b/Source/EventFlow.TestHelpers/MsSql/MsSqlConnectionString.cs
@@ -1,18 +1,19 @@
 ﻿// The MIT License (MIT)
-//
-// Copyright (c) 2015 Rasmus Mikkelsen
-// https://github.com/rasmus/Helpz
-//
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 // the Software, and to permit persons to whom the Software is furnished to do so,
 // subject to the following conditions:
-//
+// 
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 // FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR

--- a/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/CancellationTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/LicenseHeaderTests.cs
+++ b/Source/EventFlow.Tests/LicenseHeaderTests.cs
@@ -1,0 +1,104 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EventFlow.Tests
+{
+    public class LicenseHeaderTests
+    {
+        private static readonly char[] LineSplitters = {'\n', '\r'};
+
+        [Test]
+        public async Task EveryFileHasLicenseHeader()
+        {
+            var projectRoot = Helpers.GetProjectRoot();
+            var sourceFilesPaths = GetSourceFilePaths(projectRoot);
+
+            var sourceFiles = await Task.WhenAll(sourceFilesPaths.Select(GetSourceFileAsync));
+
+            var missingHeaders = sourceFiles
+                .Where(s => s.License.Count < 20)
+                .ToList();
+            
+            missingHeaders.ForEach(Console.WriteLine);
+
+            missingHeaders.Should().BeEmpty();
+        }
+
+        private static IEnumerable<string> GetSourceFilePaths(
+            string directory)
+        {
+            var objDir = $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}";
+            return Directory.EnumerateFiles(directory, "*.cs", SearchOption.AllDirectories)
+                .Where(p => !p.Contains(objDir));
+        }
+
+        private static async Task<SourceFile> GetSourceFileAsync(string path)
+        {
+            if (!File.Exists(path))
+            {
+                throw new ArgumentException($"File not found: {path}", nameof(path));
+            }
+
+            string content;
+            using (var file = File.OpenText(path))
+            {
+                content = await file.ReadToEndAsync();
+            }
+
+            var license = content
+                .Split(LineSplitters, StringSplitOptions.RemoveEmptyEntries)
+                .TakeWhile(l => l.StartsWith("//"))
+                .ToList();
+
+            return new SourceFile(
+                path,
+                license);
+        }
+
+        private class SourceFile
+        {
+            public string Path { get; }
+            public IReadOnlyCollection<string> License { get; }
+
+            public SourceFile(
+                string path,
+                IReadOnlyCollection<string> license)
+            {
+                Path = path;
+                License = license;
+            }
+
+            public override string ToString()
+            {
+                return Path;
+            }
+        }
+    }
+}

--- a/Source/EventFlow.Tests/LicenseHeaderTests.cs
+++ b/Source/EventFlow.Tests/LicenseHeaderTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -61,7 +62,7 @@ namespace EventFlow.Tests
 
             // Missing name in header as defined by the CLA (current license)
             var missingNameInHeader = sourceFiles
-                .Where(s => s.License.All(l => !l.Contains("Rasmus Mikkelsen")))
+                .Where(s => !s.License.Any(l => l.Contains("Rasmus Mikkelsen")) || !s.License.Any(l => l.Contains("eBay Software Foundation")))
                 .Where(s => !ExternalFiles.Contains(PathRelativeTo(sourceRoot, s.Path)))
                 .ToList();
             Console.WriteLine("File with incorrect name in header according to CLA");

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Configuration.Serialization;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Configuration.Serialization;
 using EventFlow.Extensions;
 using EventFlow.TestHelpers;
 using EventFlow.ValueObjects;
@@ -6,10 +28,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EventFlow.Tests.UnitTests.Configuration.Serialization
 {

--- a/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Configuration/Serialization/JsonOptionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/BootstrapExtensionTests.cs
@@ -1,4 +1,26 @@
-﻿using System.Threading;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Threading;
 using System.Threading.Tasks;
 using EventFlow.Configuration;
 using EventFlow.Extensions;

--- a/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Core;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Core;
 using EventFlow.Extensions;
 using EventFlow.TestHelpers;
 using EventFlow.ValueObjects;
@@ -6,10 +28,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EventFlow.Tests.UnitTests.Extensions
 {

--- a/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Extensions/JsonSerializerExtensionTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
+++ b/Source/EventFlow.Tests/UnitTests/Sagas/AggregateSagas/AggregateSagaTests.cs
@@ -1,4 +1,26 @@
-﻿using EventFlow.Aggregates;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
 using EventFlow.Aggregates.ExecutionResults;
 using EventFlow.Commands;
 using EventFlow.Exceptions;

--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -9,8 +9,8 @@
     <Title>EventFlow</Title>
     <Authors>Rasmus Mikkelsen</Authors>
     <Company>Rasmus Mikkelsen</Company>
-    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2018</Copyright>
-    <Description>Async/await first CQRS+ES and DDD framework for .NET - https://geteventflow.net/</Description>
+    <Copyright>Copyright (c) Rasmus Mikkelsen 2015 - 2019</Copyright>
+    <Description>Async/await first CQRS+ES and DDD framework for .NET - https://docs.geteventflow.net/</Description>
     <PackageTags>CQRS ES event sourcing</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/eventflow/EventFlow</RepositoryUrl>

--- a/Source/EventFlow/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow/Properties/AssemblyInfo.cs
@@ -1,3 +1,25 @@
-﻿using System.Runtime.CompilerServices;
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2019 Rasmus Mikkelsen
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("EventFlow.Tests")]

--- a/Source/EventFlow/Properties/AssemblyInfo.cs
+++ b/Source/EventFlow/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
 // Copyright (c) 2015-2019 Rasmus Mikkelsen
+// Copyright (c) 2015-2019 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
This is a hard one as there might be a lot of feelings involved.

This PR is license header correction as several files included an incorrect header. The contributors has signed the EventFlow CLA, which in bullet (d) transfers makes any contributions to public domain and allows the contributions to be distributed under the EventFlow license, which currently have my name it its header.

This is crucial for the protection of the project itself, and any who uses the project, as any contributor who didn't sign the CLA would be able to **withdraw** their contributions otherwise.

When contributing to EventFlow, any PR needs to have signed the CLA.

The EventFlow CLA

https://cla-assistant.io/eventflow/EventFlow

> By making a contribution to this project, I certify that:
>
>(a) The contribution was created in whole or in part by me and I have the right to submit it under the MIT license; or
>
>(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the MIT license; or
>
>(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
>
> (d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

Sorry @rmess, this might seem like a dick move, but I do hope that you understand that I really want to protect the project, the community and anyone who currently uses EventFlow.
