### PR TITLE
Added quoting to generator of the SQL.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,6 @@ If you think your name is missing from the list, create a pull-request.
 
 * MongoDB cleanup and move to main repository
 
+### [Przemysław Andruszewski](https://github.com/przemyslawandruszewski)
+
+* SQL Server and PostgreSQL query generation cleanup

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ to the documentation.
 * [**Read models:**](https://docs.geteventflow.net/ReadStores.html)
   Denormalized representation of aggregate events optimized for reading fast.
   Currently there is support for these read model storage types.
+  For the SQL storage types the queries are being generated automatically with quoted columns and table names.
   * [Elasticsearch](https://docs.geteventflow.net/ReadStores.html#elasticsearch)
   * [In-memory](https//docs.geteventflow.net/ReadStores.html#in-memory) - only for test
   * [Microsoft SQL Server](https://docs.geteventflow.net/ReadStores.html#microsoft-sql-server)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,18 @@
 
 * Updated LibLog provider to support structured logging with NLog 4.5. 
   Reduced memory allocations for log4net-provider.
+* Added quoting to the SQL query generator for the column names
+```sql
+  -- query before the fix
+    UPDATE [ReadModel-TestAttributes]
+    SET UpdatedTime = @UpdatedTime
+    WHERE Id = @Id
+  
+  -- query after the fix
+    UPDATE [ReadModel-TestAttributes]
+    SET [UpdatedTime] = @UpdatedTime
+    WHERE [Id] = @Id
+  ```
 
 ### New in 0.77.4077 (released 2019-12-10)
 

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -59,11 +59,6 @@ namespace EventFlow.PostgreSql.TestsHelpers
             environmentServer = "localhost";
             environmentPort = "5432";
             envrionmentUsername = "postgres";
-
-            environmentServer = "event-flow2.postgres.database.azure.com";
-            environmentPort = "5432";
-            environmentPassword = "event@Flow123";
-            envrionmentUsername = "eventFlow@event-flow2";
             
             connectionstringParts.Add(string.IsNullOrEmpty(environmentServer)
                 ? @"Server=localhost"

--- a/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
+++ b/Source/EventFlow.PostgreSql.Tests/TestHelpers/PostgresSqlHelpz.cs
@@ -54,11 +54,17 @@ namespace EventFlow.PostgreSql.TestsHelpers
             var environmentPassword = Environment.GetEnvironmentVariable("HELPZ_POSTGRESQL_PASS");
             var envrionmentUsername = Environment.GetEnvironmentVariable("HELPZ_POSTGRESQL_USER", EnvironmentVariableTarget.Machine);
 
+            
 
             environmentServer = "localhost";
             environmentPort = "5432";
             envrionmentUsername = "postgres";
 
+            environmentServer = "event-flow2.postgres.database.azure.com";
+            environmentPort = "5432";
+            environmentPassword = "event@Flow123";
+            envrionmentUsername = "eventFlow@event-flow2";
+            
             connectionstringParts.Add(string.IsNullOrEmpty(environmentServer)
                 ? @"Server=localhost"
                 : $"Server={environmentServer}");

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -42,7 +42,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateInsertSql<TestAttributesReadModel>();
 
             // Assert
-            sql.Should().Be("INSERT INTO [ReadModel-TestAttributes] (Id, UpdatedTime) VALUES (@Id, @UpdatedTime)");
+            sql.Should().Be("INSERT INTO [ReadModel-TestAttributes] ([Id], [UpdatedTime]) VALUES (@Id, @UpdatedTime)");
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateUpdateSql<TestAttributesReadModel>().Trim();
 
             // Assert
-            sql.Should().Be("UPDATE [ReadModel-TestAttributes] SET UpdatedTime = @UpdatedTime WHERE Id = @Id");
+            sql.Should().Be("UPDATE [ReadModel-TestAttributes] SET [UpdatedTime] = @UpdatedTime WHERE [Id] = @Id");
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateUpdateSql<TestVersionedAttributesReadModel>().Trim();
 
             // Assert
-            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET FancyVersion = @FancyVersion WHERE CoolId = @CoolId AND FancyVersion = @_PREVIOUS_VERSION");
+            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET [FancyVersion] WHERE [CoolId] = @CoolId AND [FancyVersion] = @_PREVIOUS_VERSION");
         }
 
         [Test]

--- a/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
+++ b/Source/EventFlow.Sql.Tests/UnitTests/ReadModels/ReadModelSqlGeneratorTests.cs
@@ -62,7 +62,7 @@ namespace EventFlow.Sql.Tests.UnitTests.ReadModels
             var sql = Sut.CreateUpdateSql<TestVersionedAttributesReadModel>().Trim();
 
             // Assert
-            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET [FancyVersion] WHERE [CoolId] = @CoolId AND [FancyVersion] = @_PREVIOUS_VERSION");
+            sql.Should().Be("UPDATE [ReadModel-TestVersionedAttributes] SET [FancyVersion] = @FancyVersion WHERE [CoolId] = @CoolId AND [FancyVersion] = @_PREVIOUS_VERSION");
         }
 
         [Test]

--- a/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
+++ b/Source/EventFlow.Sql/Extensions/SqlStringExtensions.cs
@@ -1,0 +1,59 @@
+﻿// The MIT License (MIT)
+// 
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
+// https://github.com/eventflow/EventFlow
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventFlow.Sql.Extensions
+{
+    public static class SqlStringExtensions
+    {
+        public static IEnumerable<string> SelectToQuotedColumns(
+            this IEnumerable<string> columns,
+            string quotedIdentifierPrefix,
+            string quotedIdentifierSuffix)
+            => columns.Select(x => GetQuotedColumn(quotedIdentifierPrefix, quotedIdentifierSuffix, x));
+
+        public static IEnumerable<string> SelectToUpdateQuotedColumnsByParameters(
+            this IEnumerable<string> columns,
+            string quotedIdentifierPrefix,
+            string quotedIdentifierSuffix)
+            => columns.Select(
+                x => $"{GetQuotedColumn(quotedIdentifierPrefix, quotedIdentifierSuffix, x)} = {GetParameter(x)}");
+
+        public static IEnumerable<string> SelectToSqlParameters(this IEnumerable<string> columns)
+            => columns.Select(x => $"@{x}");
+
+        public static string JoinToSql(this IEnumerable<string> columns, string separator = ", ")
+            => string.Join(separator, columns);
+
+        private static string GetParameter(string value)
+            => $"@{value}";
+
+        private static string GetQuotedColumn(
+            string quotedIdentifierPrefix,
+            string quotedIdentifierSuffix,
+            string value)
+            => $"{quotedIdentifierPrefix}{value}{quotedIdentifierSuffix}";
+    }
+}

--- a/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
+++ b/Source/EventFlow.Sql/ReadModels/ReadModelSqlGeneratorConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿// The MIT License (MIT)
 // 
-// Copyright (c) 2015-2019 Rasmus Mikkelsen
-// Copyright (c) 2015-2019 eBay Software Foundation
+// Copyright (c) 2015-2018 Rasmus Mikkelsen
+// Copyright (c) 2015-2018 eBay Software Foundation
 // https://github.com/eventflow/EventFlow
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,16 +21,28 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System;
-using EventFlow.Sql.ReadModels;
-
-namespace EventFlow.PostgreSql.ReadModels
+namespace EventFlow.Sql.ReadModels
 {
-    public class PostgresReadModelSqlGenerator : ReadModelSqlGenerator
+    public class ReadModelSqlGeneratorConfiguration
     {
-        public PostgresReadModelSqlGenerator()
-            : base(new ReadModelSqlGeneratorConfiguration("\"", "\"", string.Empty, string.Empty))
+        public ReadModelSqlGeneratorConfiguration(
+            string tableQuotedIdentifierPrefix,
+            string tableQuotedIdentifierSuffix,
+            string columnQuotedIdentifierPrefix,
+            string columnQuotedIdentifierSuffix)
         {
+            TableQuotedIdentifierPrefix = tableQuotedIdentifierPrefix;
+            TableQuotedIdentifierSuffix = tableQuotedIdentifierSuffix;
+            ColumnQuotedIdentifierPrefix = columnQuotedIdentifierPrefix;
+            ColumnQuotedIdentifierSuffix = columnQuotedIdentifierSuffix;
         }
+
+        public string TableQuotedIdentifierPrefix { get; set; }
+
+        public string TableQuotedIdentifierSuffix { get; set; }
+
+        public string ColumnQuotedIdentifierPrefix { get; set; }
+
+        public string ColumnQuotedIdentifierSuffix { get; set; }
     }
 }


### PR DESCRIPTION
That is the first step I would like to propose for the EventFlow, in the part of generation the SQL. What is does is quoting the column names while generating selects, updates or deletes. Those problems may be related mostly to SQL Server, to the problems while for instance you named your column:"UniqueIdentifier" which is data type in sql or you just have a column in your table that has the same name as system(SQL) tables or their columns.
The second step I would like to propose(if you approve the first one of course) is to propose a bit different way of generating those SQL with library like maybe Dapper but that is after I will make sure it will work for us.