### PR TITLE
Entity Framework on .NET Core 3.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 ### New in 0.78 (not released yet)
 
+* New: Added .NET Core 3.1 target for the `EventFlow`
+  and `EventFlow.EntityFramework` packages
 * Updated LibLog provider to support structured logging with NLog 4.5. 
   Reduced memory allocations for log4net-provider.
 * Added quoting to the SQL query generator for the column names

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,11 @@
 ### New in 0.79 (not released yet)
 
-* _Nothing yet_
-
-### New in 0.78.4205 (released 2020-05-11)
-
 * New: Added .NET Core 3.1 target for the `EventFlow`
   and `EventFlow.EntityFramework` packages
 * Added quoting to the SQL query generator for the column names
+
+### New in 0.78.4205 (released 2020-05-11)
+
 * New: Updated LibLog provider to support structured logging with NLog 4.5. 
   Reduced memory allocations for log4net-provider
 * New: Made several methods in `AggregateRoot<,>` `virtual` to allow

--- a/Source/EventFlow.EntityFramework.Tests/EventFlow.EntityFramework.Tests.csproj
+++ b/Source/EventFlow.EntityFramework.Tests/EventFlow.EntityFramework.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/Source/EventFlow.EntityFramework/EventFlow.EntityFramework.csproj
+++ b/Source/EventFlow.EntityFramework/EventFlow.EntityFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -23,7 +23,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore">
-      <Version>2.1.0</Version>
+      <Version>2.2.6</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore">
+      <Version>3.1.1</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/Source/EventFlow/EventFlow.csproj
+++ b/Source/EventFlow/EventFlow.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.6;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6;netstandard2.0;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
This adds multi-targeting for EventFlow.EntityFramework: For `netcoreapp3.1` targets we now use Entity Framework 3.1.1.

Fixes #718 