### PR TITLE
EntityFramework: SaveChanges per event

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,9 @@
   in favor of the simpler overloads with less type parameters (as those automatically
   figure out the AggregateRoot and Id types and configure the more reliable 
   `SingleAggregateReadStoreManager` implementation)
+* Fixed: An issue where `EntityFrameworkEventPersistence` could possibly save aggregate 
+  events out of order, which would lead to out-of-order application when streaming events
+  ordered by GlobalSequenceNumber
 
 ### New in 0.79.4216 ((released 2020-05-13)
 

--- a/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
+++ b/Source/EventFlow.EntityFramework/EventStores/EntityFrameworkEventPersistence.cs
@@ -106,9 +106,11 @@ namespace EventFlow.EntityFramework.EventStores
             {
                 using (var context = _contextProvider.CreateContext())
                 {
-                    context.AddRange(entities);
-                    await context.SaveChangesAsync(cancellationToken)
-                        .ConfigureAwait(false);
+                    foreach (EventEntity entity in entities)
+                    {
+                        context.Add(entity);
+                        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
             catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation(_strategy))


### PR DESCRIPTION
Entity Framework seems to make no guarantees about insertion order when using `AddRange`. This might lead to aggregate events with invalid GlobalSequenceNumber order.

I changed the code to call `SaveChanges` for every event.

This fixes #691 
