### PR TITLE
Fix MultipleAggregateReadStoreManagerTests

### DIFF
--- a/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
+++ b/Source/EventFlow.Tests/IntegrationTests/ReadStores/MultipleAggregateReadStoreManagerTests.cs
@@ -21,6 +21,7 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,7 +46,6 @@ namespace EventFlow.Tests.IntegrationTests.ReadStores
         private const string ReadModelId = "the one";
         
         [Test]
-        [Ignore("Test unstable, issue #710")]
         public async Task EventOrdering()
         {
             // Repopulating read models that span multiple aggregates should have their events
@@ -56,8 +56,11 @@ namespace EventFlow.Tests.IntegrationTests.ReadStores
             var idB = IdB.New;
             var i = 0;
             await CommandBus.PublishAsync(new CommandA(idA, i++), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
             await CommandBus.PublishAsync(new CommandA(idA, i++), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
             await CommandBus.PublishAsync(new CommandB(idB, i++), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
             await CommandBus.PublishAsync(new CommandB(idB, i++), CancellationToken.None);
             await ReadModelPopulator.PurgeAsync(typeof(ReadModelAB), CancellationToken.None);
 


### PR DESCRIPTION
```csharp
// Repopulating read models that span multiple aggregates should have their events
// applied in order using events time stamps
```

```
AggregateA v1 ==================================
{
  "timestamp": "2020-07-05T10:20:01.6806857+00:00", (...)
}
AggregateA v2 ==================================
{
  "timestamp": "2020-07-05T10:20:01.6963165+00:00", (...)
}
AggregateB v1 ==================================
{
  "timestamp": "2020-07-05T10:20:01.6963165+00:00", (...)
}
AggregateB v2 ==================================
{
  "timestamp": "2020-07-05T10:20:01.6963165+00:00", (...)
}
```

The timestamps of some events are identical, that's why sorting them mixes things up a bit. Even when I add 1ms delays between the calls, the timestamps still match as the clock resolution seems too low. I raised the delay to 10ms, now it's working.

We wouldn't need to do this if we just used the GlobalSequenceNumber, but I don't know if we would gain anything else by this.

Fixes #710 