### PR TITLE
Fix exception message for when it does not have an 'Apply' method that takes aggregate event

### DIFF
--- a/Source/EventFlow/Aggregates/AggregateRoot.cs
+++ b/Source/EventFlow/Aggregates/AggregateRoot.cs
@@ -197,7 +197,7 @@ namespace EventFlow.Aggregates
                 if (!ApplyMethods.TryGetValue(eventType, out var applyMethod))
                 {
                     throw new NotImplementedException(
-                        $"Aggregate '{Name}' does have an 'Apply' method that takes aggregate event '{eventType.PrettyPrint()}' as argument");
+                        $"Aggregate '{Name}' does not have an 'Apply' method that takes aggregate event '{eventType.PrettyPrint()}' as argument");
                 }
 
                 applyMethod(this as TAggregate, aggregateEvent);


### PR DESCRIPTION
I think the exception message is wrong. It should state that it does NOT have an 'Apply' method.