### PR TITLE
[PoC] Adding Kafka as Event Publishing Alternative to Rabbit

### DIFF
--- a/EventFlow.sln
+++ b/EventFlow.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow", "Source\EventFlow\EventFlow.csproj", "{11131251-778D-4D2E-BDD1-4844A789BCA9}"
 EndProject
@@ -100,6 +100,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.MongoDB", "Source\EventFlow.MongoDB\EventFlow.MongoDB.csproj", "{C34BFD0C-E7CD-4DEE-A1F4-8FBE9DE0B239}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.MongoDB.Tests", "Source\EventFlow.MongoDB.Tests\EventFlow.MongoDB.Tests.csproj", "{2D837E47-E92B-422E-AC29-AB5607E9E6D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.Kafka", "Source\EventFlow.Kafka\EventFlow.Kafka.csproj", "{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Kafka", "Kafka", "{B012BBEF-55FB-4895-872B-0F5A41D3688B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -243,6 +247,10 @@ Global
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -282,6 +290,7 @@ Global
 		{5B2706DA-B66C-4CD9-8441-8C9BDACB8348} = {92F3C263-8C0C-4D12-B41A-452E48D2E5E8}
 		{C34BFD0C-E7CD-4DEE-A1F4-8FBE9DE0B239} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
+		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F} = {B012BBEF-55FB-4895-872B-0F5A41D3688B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17607E2C-4E8E-45A2-85BD-0A5808E1C0F3}

--- a/EventFlow.sln
+++ b/EventFlow.sln
@@ -101,9 +101,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.MongoDB", "Source
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.MongoDB.Tests", "Source\EventFlow.MongoDB.Tests\EventFlow.MongoDB.Tests.csproj", "{2D837E47-E92B-422E-AC29-AB5607E9E6D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.Kafka", "Source\EventFlow.Kafka\EventFlow.Kafka.csproj", "{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventFlow.Kafka", "Source\EventFlow.Kafka\EventFlow.Kafka.csproj", "{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Kafka", "Kafka", "{B012BBEF-55FB-4895-872B-0F5A41D3688B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventFlow.Kafka.Tests", "Source\EventFlow.Kafka.Tests\EventFlow.Kafka.Tests.csproj", "{DB0B0F46-94F2-4E83-8D32-53A4CDED75D4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -251,6 +253,10 @@ Global
 		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB0B0F46-94F2-4E83-8D32-53A4CDED75D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB0B0F46-94F2-4E83-8D32-53A4CDED75D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB0B0F46-94F2-4E83-8D32-53A4CDED75D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB0B0F46-94F2-4E83-8D32-53A4CDED75D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -291,6 +297,7 @@ Global
 		{C34BFD0C-E7CD-4DEE-A1F4-8FBE9DE0B239} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
 		{2D837E47-E92B-422E-AC29-AB5607E9E6D1} = {7832AC5E-5CE2-4694-BA43-E53222B75EDC}
 		{EA7ADBD1-2A44-4219-95C0-ECE3CB0E275F} = {B012BBEF-55FB-4895-872B-0F5A41D3688B}
+		{DB0B0F46-94F2-4E83-8D32-53A4CDED75D4} = {B012BBEF-55FB-4895-872B-0F5A41D3688B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17607E2C-4E8E-45A2-85BD-0A5808E1C0F3}

--- a/Source/EventFlow.Kafka.Tests/EventFlow.Kafka.Tests.csproj
+++ b/Source/EventFlow.Kafka.Tests/EventFlow.Kafka.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
+
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+		<PackageReference Include="coverlet.collector" Version="1.2.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventFlow.TestHelpers\EventFlow.TestHelpers.csproj" />
+		<ProjectReference Include="..\EventFlow.Kafka\EventFlow.Kafka.csproj" />
+	</ItemGroup>
+</Project>

--- a/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
+++ b/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
@@ -15,40 +15,54 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Assert = NUnit.Framework.Assert;
 
 namespace EventFlow.Kafka.Tests.Integration
 {
     [Category(Categories.Integration)]
     public class KafkaTests
     {
+
+        private string _uri;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _uri = Environment.GetEnvironmentVariable("KAFKA_URL");
+            if (string.IsNullOrEmpty(_uri))
+            {
+                Assert.Inconclusive("The environment variable named 'KAFKA_URL' isn't set. Set it to e.g. 'localhost:9092'");
+            }
+        }
+
         [Test, Timeout(10000), Retry(3)]
         public async Task Scenario()
         {
             try
             {
-
-
                 using (var consumer = new ConsumerBuilder<string, string>(new ConsumerConfig
                 {
-                    GroupId = "test-consumer-group",
-                    BootstrapServers = "localhost:9092",
-                    AutoOffsetReset = AutoOffsetReset.Earliest,
+                    GroupId = Guid.NewGuid().ToString(),
+                    BootstrapServers = _uri,
+                    AutoOffsetReset = AutoOffsetReset.Earliest
                 }).Build())
                 using (var resolver = BuildResolver())
                 {
-                    consumer.Subscribe("eventflow.domainevent.thingy.thingy-ping");
+                    
                     var commandBus = resolver.Resolve<ICommandBus>();
                     var eventJsonSerializer = resolver.Resolve<IEventJsonSerializer>();
 
                     var pingId = PingId.New;
                     await commandBus.PublishAsync(new ThingyPingCommand(ThingyId.New, pingId), CancellationToken.None).ConfigureAwait(false);
 
+                    consumer.Subscribe("eventflow.domainevent.thingy.thingy-ping");
                     var kafkaMessage = consumer.Consume(CancellationToken.None);
-
+                    
                     kafkaMessage.TopicPartition.Topic.Should().Be("eventflow.domainevent.thingy.thingy-ping");
 
                     var pingEvent = (DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>)eventJsonSerializer.Deserialize(
@@ -73,7 +87,7 @@ namespace EventFlow.Kafka.Tests.Integration
             configure = configure ?? (e => e);
 
             return configure(EventFlowOptions.New
-                .PublishToKafka(new ProducerConfig { BootstrapServers = "localhost:9092" })
+                .PublishToKafka(new ProducerConfig { BootstrapServers = _uri })
                 .AddDefaults(EventFlowTestHelpers.Assembly))
                 .RegisterServices(sr => sr.Register<IScopedContext, ScopedContext>(Lifetime.Scoped))
                 .CreateResolver(false);

--- a/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
+++ b/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
@@ -1,14 +1,84 @@
-﻿using EventFlow.TestHelpers;
+﻿using Confluent.Kafka;
+using EventFlow.Aggregates;
+using EventFlow.Configuration;
+using EventFlow.Core;
+using EventFlow.EventStores;
+using EventFlow.Extensions;
+using EventFlow.Kafka.Extensions;
+using EventFlow.Kafka.Integrations;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Commands;
+using EventFlow.TestHelpers.Aggregates.Events;
+using EventFlow.TestHelpers.Aggregates.Queries;
+using EventFlow.TestHelpers.Aggregates.ValueObjects;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventFlow.Kafka.Tests.Integration
 {
     [Category(Categories.Integration)]
     public class KafkaTests
     {
+        [Test, Timeout(10000), Retry(3)]
+        public async Task Scenario()
+        {
+            try
+            {
 
+
+                using (var consumer = new ConsumerBuilder<string, string>(new ConsumerConfig
+                {
+                    GroupId = "test-consumer-group",
+                    BootstrapServers = "localhost:9092",
+                    AutoOffsetReset = AutoOffsetReset.Earliest,
+                }).Build())
+                using (var resolver = BuildResolver())
+                {
+                    consumer.Subscribe("thingy");
+                    var commandBus = resolver.Resolve<ICommandBus>();
+                    var eventJsonSerializer = resolver.Resolve<IEventJsonSerializer>();
+
+                    var pingId = PingId.New;
+                    await commandBus.PublishAsync(new ThingyPingCommand(ThingyId.New, pingId), CancellationToken.None).ConfigureAwait(false);
+
+                    var kafkaMessage = consumer.Consume(CancellationToken.None);
+                    //kafkaMessage.Exchange.Value.Should().Be(exchange.Value);
+                    //kafkaMessage.RoutingKey.Value.Should().Be("eventflow.domainevent.thingy.thingy-ping.1");
+
+                    var pingEvent = (DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>)eventJsonSerializer.Deserialize(
+                        kafkaMessage.Message.Value,
+                        new Aggregates.Metadata(kafkaMessage.Message.Headers
+                        .ToDictionary(
+                            x => x.Key,
+                            x => Encoding.UTF8.GetString(x.GetValueBytes()))));
+
+                    pingEvent.AggregateEvent.PingId.Should().Be(pingId);
+                }
+            }
+            catch (Exception e)
+            {
+
+                throw;
+            }
+        }
+
+        private IRootResolver BuildResolver(Func<IEventFlowOptions, IEventFlowOptions> configure = null)
+        {
+            configure = configure ?? (e => e);
+
+            return configure(EventFlowOptions.New
+                .PublishToKafka(new ProducerConfig { BootstrapServers = "localhost:9092" })
+                .AddDefaults(EventFlowTestHelpers.Assembly))
+                .RegisterServices(sr => sr.Register<IScopedContext, ScopedContext>(Lifetime.Scoped))
+                .CreateResolver(false);
+        }
     }
 }

--- a/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
+++ b/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
@@ -1,4 +1,27 @@
-﻿using Confluent.Kafka;
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Confluent.Kafka;
 using EventFlow.Aggregates;
 using EventFlow.Configuration;
 using EventFlow.Core;
@@ -15,7 +38,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;

--- a/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
+++ b/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
@@ -1,0 +1,14 @@
+﻿using EventFlow.TestHelpers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EventFlow.Kafka.Tests.Integration
+{
+    [Category(Categories.Integration)]
+    public class KafkaTests
+    {
+
+    }
+}

--- a/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
+++ b/Source/EventFlow.Kafka.Tests/Integration/KafkaTests.cs
@@ -5,7 +5,6 @@ using EventFlow.Core;
 using EventFlow.EventStores;
 using EventFlow.Extensions;
 using EventFlow.Kafka.Extensions;
-using EventFlow.Kafka.Integrations;
 using EventFlow.TestHelpers;
 using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Commands;
@@ -16,7 +15,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -42,7 +40,7 @@ namespace EventFlow.Kafka.Tests.Integration
                 }).Build())
                 using (var resolver = BuildResolver())
                 {
-                    consumer.Subscribe("thingy");
+                    consumer.Subscribe("eventflow.domainevent.thingy.thingy-ping");
                     var commandBus = resolver.Resolve<ICommandBus>();
                     var eventJsonSerializer = resolver.Resolve<IEventJsonSerializer>();
 
@@ -50,8 +48,8 @@ namespace EventFlow.Kafka.Tests.Integration
                     await commandBus.PublishAsync(new ThingyPingCommand(ThingyId.New, pingId), CancellationToken.None).ConfigureAwait(false);
 
                     var kafkaMessage = consumer.Consume(CancellationToken.None);
-                    //kafkaMessage.Exchange.Value.Should().Be(exchange.Value);
-                    //kafkaMessage.RoutingKey.Value.Should().Be("eventflow.domainevent.thingy.thingy-ping.1");
+
+                    kafkaMessage.TopicPartition.Topic.Should().Be("eventflow.domainevent.thingy.thingy-ping");
 
                     var pingEvent = (DomainEvent<ThingyAggregate, ThingyId, ThingyPingEvent>)eventJsonSerializer.Deserialize(
                         kafkaMessage.Message.Value,

--- a/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaMessageFactoryTests.cs
+++ b/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaMessageFactoryTests.cs
@@ -1,20 +1,38 @@
-﻿using AutoFixture;
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using AutoFixture;
 using Confluent.Kafka;
 using EventFlow.Aggregates;
 using EventFlow.EventStores;
-using EventFlow.Extensions;
 using EventFlow.Kafka.Integrations;
 using EventFlow.TestHelpers;
-using EventFlow.TestHelpers.Aggregates;
 using EventFlow.TestHelpers.Aggregates.Events;
-using EventFlow.TestHelpers.Extensions;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace EventFlow.Kafka.Tests.UnitTests.Integrations
 {

--- a/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaMessageFactoryTests.cs
+++ b/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaMessageFactoryTests.cs
@@ -1,0 +1,100 @@
+﻿using AutoFixture;
+using Confluent.Kafka;
+using EventFlow.Aggregates;
+using EventFlow.EventStores;
+using EventFlow.Extensions;
+using EventFlow.Kafka.Integrations;
+using EventFlow.TestHelpers;
+using EventFlow.TestHelpers.Aggregates;
+using EventFlow.TestHelpers.Aggregates.Events;
+using EventFlow.TestHelpers.Extensions;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EventFlow.Kafka.Tests.UnitTests.Integrations
+{
+    [Category(Categories.Unit)]
+    public class KafkaMessageFactoryTests : TestsFor<KafkaMessageFactory>
+    {
+        private ProducerConfig _kafkaConfiguration;
+        private Mock<IEventJsonSerializer> _serializerMock;
+        [SetUp]
+        public void SetUp()
+        {
+            _kafkaConfiguration = new ProducerConfig();
+            _serializerMock = new Mock<IEventJsonSerializer>();
+            _serializerMock.Setup(x => x.Serialize(It.IsAny<IAggregateEvent>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()))
+                .Returns(new SerializedEvent("", "", 0, Aggregates.Metadata.Empty));
+
+
+            Fixture.Inject(_serializerMock);
+            Fixture.Inject(_kafkaConfiguration);
+        }
+
+        public void UseCustomTopicFactory()
+        {
+            Fixture.Inject<Func<IDomainEvent, TopicPartition>>((IDomainEvent e) =>
+            {
+                return new TopicPartition(e.AggregateType.FullName, new Partition(e.AggregateSequenceNumber));
+            });
+        }
+
+        public void UseDefaultTopicFactory()
+        {
+            Fixture.Inject<Func<IDomainEvent, TopicPartition>>(null);
+        }
+
+
+        [Test]
+        public void DefaultTopicFactoryIsUsedWhenACustomIsNotProvided()
+        {
+            // Arrange
+            UseDefaultTopicFactory();
+            var metaData = new Aggregates.Metadata
+            {
+                AggregateName = "thingy",
+                EventName = "thingyping"
+            };
+            var domainMessage = ADomainEvent<ThingyPingEvent>(initMetadata: metaData);
+
+            // Act
+            var kafkaMessage = Sut.CreateMessage(domainMessage);
+
+
+            // Assert
+            kafkaMessage.TopicPartition.Topic.Should().Be("eventflow.domainevent.thingy.thingyping");
+
+            kafkaMessage.TopicPartition.Partition.Value.Should().Be(0);
+        }
+
+        [Test]
+        public void CustomTopicFactoryIsUsedWhenProvided()
+        {
+            // Arrange
+            UseCustomTopicFactory();
+            var metaData = new Aggregates.Metadata
+            {
+                AggregateName = "thingy",
+                EventName = "thingyping"
+            };
+
+            var domainMessage = ADomainEvent<ThingyPingEvent>(initMetadata: metaData);
+
+            // Act
+            var kafkaMessage = Sut.CreateMessage(domainMessage);
+
+
+            // Assert
+            kafkaMessage.TopicPartition.Topic.Should().Be("EventFlow.TestHelpers.Aggregates.ThingyAggregate");
+
+            kafkaMessage.TopicPartition.Partition.Value.Should().Be(domainMessage.AggregateSequenceNumber);
+        }
+
+
+    }
+}

--- a/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
+++ b/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
@@ -1,3 +1,26 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using System;
 using System.Linq;
 using System.Threading;

--- a/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
+++ b/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow.Core;
+using EventFlow.Logs;
+using EventFlow.TestHelpers;
+using AutoFixture;
+using Moq;
+using NUnit.Framework;
+using EventFlow.Kafka.Integrations;
+using Confluent.Kafka;
+
+namespace EventFlow.Kafka.Tests
+{
+    [Category(Categories.Unit)]
+    public class KafkaPublisherTests : TestsFor<KafkaPublisher>
+    {
+        private Mock<IKafkaProducerFactory> _kafkaProducerFactory;
+        private ProducerConfig _kafkaConfiguration;
+        private Mock<ILog> _logMock;
+        private Mock<IProducer<string, KafkaMessage>> _producerMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _kafkaProducerFactory = InjectMock<IKafkaProducerFactory>();
+            _kafkaConfiguration = new ProducerConfig();
+            Fixture.Inject(_kafkaConfiguration);
+            _logMock = InjectMock<ILog>();
+
+            Fixture.Inject<ITransientFaultHandler<IKafkaRetryStrategy>>(new TransientFaultHandler<IKafkaRetryStrategy>(
+                _logMock.Object,
+                new KafkaRetryStrategy()));
+
+            _producerMock = new Mock<IProducer<string, KafkaMessage>>();
+
+            _kafkaProducerFactory
+                .Setup(f => f.CreateProducer())
+                .Returns(_producerMock.Object);
+
+        }
+
+        private void ArrangeBrokenPublisher<TException>()
+            where TException : Exception, new()
+        {
+            _producerMock
+                .Setup(c => c.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, KafkaMessage>>(), It.IsAny<CancellationToken>()))
+                .Throws<TException>();
+        }
+
+
+        [Test]
+        public async Task PublishIsCalled()
+        {
+            // Arrange
+            var kafkaMessages = Fixture.CreateMany<KafkaMessage>().ToList();
+
+            // Act
+            await Sut.PublishAsync(kafkaMessages, CancellationToken.None);
+
+            // Assert
+            _producerMock.Verify(m => m.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, KafkaMessage>>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(kafkaMessages.Count));
+
+            _producerMock.Verify(c => c.Dispose(), Times.Never);
+        }
+
+        [Test]
+        public void ConnectionIsDisposedOnException()
+        {
+            // Arrange
+            ArrangeBrokenPublisher<ArgumentException>();
+            var kafkaMessages = Fixture.CreateMany<KafkaMessage>().ToList();
+
+            // Act
+            Assert.ThrowsAsync<ArgumentException>(
+                async () => await Sut.PublishAsync(kafkaMessages, CancellationToken.None));
+
+            // Assert
+            _producerMock.Verify(c => c.Dispose(), Times.Once);
+        }
+
+
+    }
+}

--- a/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
+++ b/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
@@ -45,8 +45,15 @@ namespace EventFlow.Kafka.Tests
             where TException : Exception, new()
         {
             _producerMock
-                .Setup(c => c.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.ProduceAsync(It.IsAny<TopicPartition>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()))
                 .Throws<TException>();
+        }
+
+        private void ArrangeWorkingPublisher()
+        {
+            _producerMock
+                .Setup(c => c.ProduceAsync(It.IsAny<TopicPartition>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()))
+                .Verifiable();
         }
 
 
@@ -54,13 +61,14 @@ namespace EventFlow.Kafka.Tests
         public async Task PublishIsCalled()
         {
             // Arrange
+            ArrangeWorkingPublisher();
             var kafkaMessages = Fixture.CreateMany<KafkaMessage>().ToList();
 
             // Act
             await Sut.PublishAsync(kafkaMessages, CancellationToken.None);
 
             // Assert
-            _producerMock.Verify(m => m.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()),
+            _producerMock.Verify(m => m.ProduceAsync(It.IsAny<TopicPartition>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(kafkaMessages.Count));
 
             _producerMock.Verify(c => c.Dispose(), Times.Never);

--- a/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
+++ b/Source/EventFlow.Kafka.Tests/UnitTests/Integrations/KafkaPublisherTests.cs
@@ -19,7 +19,7 @@ namespace EventFlow.Kafka.Tests
         private Mock<IKafkaProducerFactory> _kafkaProducerFactory;
         private ProducerConfig _kafkaConfiguration;
         private Mock<ILog> _logMock;
-        private Mock<IProducer<string, KafkaMessage>> _producerMock;
+        private Mock<IProducer<string, string>> _producerMock;
 
         [SetUp]
         public void SetUp()
@@ -33,7 +33,7 @@ namespace EventFlow.Kafka.Tests
                 _logMock.Object,
                 new KafkaRetryStrategy()));
 
-            _producerMock = new Mock<IProducer<string, KafkaMessage>>();
+            _producerMock = new Mock<IProducer<string, string>>();
 
             _kafkaProducerFactory
                 .Setup(f => f.CreateProducer())
@@ -45,7 +45,7 @@ namespace EventFlow.Kafka.Tests
             where TException : Exception, new()
         {
             _producerMock
-                .Setup(c => c.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, KafkaMessage>>(), It.IsAny<CancellationToken>()))
+                .Setup(c => c.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()))
                 .Throws<TException>();
         }
 
@@ -60,7 +60,7 @@ namespace EventFlow.Kafka.Tests
             await Sut.PublishAsync(kafkaMessages, CancellationToken.None);
 
             // Assert
-            _producerMock.Verify(m => m.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, KafkaMessage>>(), It.IsAny<CancellationToken>()),
+            _producerMock.Verify(m => m.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, string>>(), It.IsAny<CancellationToken>()),
                 Times.Exactly(kafkaMessages.Count));
 
             _producerMock.Verify(c => c.Dispose(), Times.Never);

--- a/Source/EventFlow.Kafka/EventFlow.Kafka.csproj
+++ b/Source/EventFlow.Kafka/EventFlow.Kafka.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Confluent.Kafka" Version="1.4.4" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\EventFlow.EventStores.EventStore\EventFlow.EventStores.EventStore.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Source/EventFlow.Kafka/Extensions/EventFlowOptionsKafkaExtensions.cs
+++ b/Source/EventFlow.Kafka/Extensions/EventFlowOptionsKafkaExtensions.cs
@@ -22,9 +22,12 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using Confluent.Kafka;
+using EventFlow.Aggregates;
 using EventFlow.Configuration;
 using EventFlow.Kafka.Integrations;
 using EventFlow.Subscribers;
+using System;
+using System.Linq.Expressions;
 
 namespace EventFlow.Kafka.Extensions
 {
@@ -32,7 +35,8 @@ namespace EventFlow.Kafka.Extensions
     {
         public static IEventFlowOptions PublishToKafka(
             this IEventFlowOptions eventFlowOptions,
-             ProducerConfig configuration)
+             ProducerConfig configuration,
+             Func<IDomainEvent, TopicPartition> topicPartitionFactory = null)
         {
             return eventFlowOptions.RegisterServices(sr =>
                 {
@@ -40,6 +44,8 @@ namespace EventFlow.Kafka.Extensions
                     sr.Register<IKafkaMessageFactory, KafkaMessageFactory>(Lifetime.Singleton);
                     sr.Register<IKafkaPublisher, KafkaPublisher>(Lifetime.Singleton);
                     sr.Register<IKafkaRetryStrategy, KafkaRetryStrategy>(Lifetime.Singleton);
+
+                    sr.Register(rc => topicPartitionFactory, Lifetime.Singleton);
 
                     sr.Register(rc => configuration, Lifetime.Singleton);
 

--- a/Source/EventFlow.Kafka/Extensions/EventFlowOptionsRabbitMqExtensions.cs
+++ b/Source/EventFlow.Kafka/Extensions/EventFlowOptionsRabbitMqExtensions.cs
@@ -1,0 +1,50 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Confluent.Kafka;
+using EventFlow.Configuration;
+using EventFlow.Kafka.Integrations;
+using EventFlow.Subscribers;
+
+namespace EventFlow.Kafka.Extensions
+{
+    public static class EventFlowOptionsKafkaExtensions
+    {
+        public static IEventFlowOptions PublishToRabbitMq(
+            this IEventFlowOptions eventFlowOptions,
+            ProducerConfig configuration)
+        {
+            return eventFlowOptions.RegisterServices(sr =>
+                {
+                    sr.Register<IKafkaProducerFactory, KafkaProducerFactory>(Lifetime.Singleton);
+                    sr.Register<IKafkaMessageFactory, KafkaMessageFactory>(Lifetime.Singleton);
+                    sr.Register<IKafkaPublisher, KafkaPublisher>(Lifetime.Singleton);
+                    sr.Register<IKafkaRetryStrategy, KafkaRetryStrategy>(Lifetime.Singleton);
+
+                    sr.Register(rc => configuration, Lifetime.Singleton);
+
+                    sr.Register<ISubscribeSynchronousToAll, KafkaDomainEventPublisher>();
+                });
+        }
+    }
+}

--- a/Source/EventFlow.Kafka/Extensions/EventFlowOptionsRabbitMqExtensions.cs
+++ b/Source/EventFlow.Kafka/Extensions/EventFlowOptionsRabbitMqExtensions.cs
@@ -30,7 +30,7 @@ namespace EventFlow.Kafka.Extensions
 {
     public static class EventFlowOptionsKafkaExtensions
     {
-        public static IEventFlowOptions PublishToRabbitMq(
+        public static IEventFlowOptions PublishToKafka(
             this IEventFlowOptions eventFlowOptions,
              ProducerConfig configuration)
         {

--- a/Source/EventFlow.Kafka/Extensions/EventFlowOptionsRabbitMqExtensions.cs
+++ b/Source/EventFlow.Kafka/Extensions/EventFlowOptionsRabbitMqExtensions.cs
@@ -32,7 +32,7 @@ namespace EventFlow.Kafka.Extensions
     {
         public static IEventFlowOptions PublishToRabbitMq(
             this IEventFlowOptions eventFlowOptions,
-            ProducerConfig configuration)
+             ProducerConfig configuration)
         {
             return eventFlowOptions.RegisterServices(sr =>
                 {

--- a/Source/EventFlow.Kafka/Integrations/IKafkaConnectionFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/IKafkaConnectionFactory.cs
@@ -1,0 +1,33 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Confluent.Kafka;
+using System.Threading.Tasks;
+
+namespace EventFlow.Kafka.Integrations
+{
+    public interface IKafkaProducerFactory
+    {
+        IProducer<string, KafkaMessage> CreateProducer();
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/IKafkaConnectionFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/IKafkaConnectionFactory.cs
@@ -28,6 +28,6 @@ namespace EventFlow.Kafka.Integrations
 {
     public interface IKafkaProducerFactory
     {
-        IProducer<string, KafkaMessage> CreateProducer();
+        IProducer<string, string> CreateProducer();
     }
 }

--- a/Source/EventFlow.Kafka/Integrations/IKafkaMessageFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/IKafkaMessageFactory.cs
@@ -1,0 +1,32 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
+
+namespace EventFlow.Kafka.Integrations
+{
+    public interface IKafkaMessageFactory
+    {
+        KafkaMessage CreateMessage(IDomainEvent e);
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/IKafkaPublisher.cs
+++ b/Source/EventFlow.Kafka/Integrations/IKafkaPublisher.cs
@@ -1,0 +1,34 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventFlow.Kafka.Integrations
+{
+    public interface IKafkaPublisher
+    {
+        Task PublishAsync(IReadOnlyCollection<KafkaMessage> rabbitMqMessages, CancellationToken cancellationToken);
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/IKafkaRetryStrategy.cs
+++ b/Source/EventFlow.Kafka/Integrations/IKafkaRetryStrategy.cs
@@ -1,0 +1,31 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Core;
+
+namespace EventFlow.Kafka.Integrations
+{
+    public interface IKafkaRetryStrategy : IRetryStrategy
+    {
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/KafkaMessage.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaMessage.cs
@@ -1,0 +1,41 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+using EventFlow.Aggregates;
+using System;
+
+namespace EventFlow.Kafka.Integrations
+{
+    public class KafkaMessage
+    {
+        public MessageId MessageId { get; set; }
+        public Guid BatchId { get; set; }
+        public string AggregateId { get; set; }
+        public string AggregateName { get; set; }
+        public IAggregateEvent Data { get; set; }
+        public IMetadata Metadata { get; set; }
+        public int AggregateSequenceNumber { get; set; }
+        public string Topic { get; set; }
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/KafkaMessage.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaMessage.cs
@@ -22,6 +22,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+using Confluent.Kafka;
 using EventFlow.Aggregates;
 using System;
 using System.Collections.Generic;
@@ -34,6 +35,6 @@ namespace EventFlow.Kafka.Integrations
         public string AggregateName { get; set; }
         public string Message { get; set; }
         public IReadOnlyDictionary<string, string> Metadata { get; set; }
-        public string Topic { get; set; }
+        public TopicPartition TopicPartition { get; set; }
     }
 }

--- a/Source/EventFlow.Kafka/Integrations/KafkaMessage.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaMessage.cs
@@ -24,18 +24,16 @@
 
 using EventFlow.Aggregates;
 using System;
+using System.Collections.Generic;
 
 namespace EventFlow.Kafka.Integrations
 {
     public class KafkaMessage
     {
         public MessageId MessageId { get; set; }
-        public Guid BatchId { get; set; }
-        public string AggregateId { get; set; }
         public string AggregateName { get; set; }
-        public IAggregateEvent Data { get; set; }
-        public IMetadata Metadata { get; set; }
-        public int AggregateSequenceNumber { get; set; }
+        public string Message { get; set; }
+        public IReadOnlyDictionary<string, string> Metadata { get; set; }
         public string Topic { get; set; }
     }
 }

--- a/Source/EventFlow.Kafka/Integrations/KafkaMessageFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaMessageFactory.cs
@@ -1,0 +1,48 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
+using EventFlow.Extensions;
+using System;
+
+
+namespace EventFlow.Kafka.Integrations
+{
+    class KafkaMessageFactory : IKafkaMessageFactory
+    {
+        public KafkaMessage CreateMessage(IDomainEvent domainEvent)
+        {
+            return new KafkaMessage
+            {
+                AggregateId = domainEvent.Metadata.AggregateId,
+                AggregateName = domainEvent.Metadata[MetadataKeys.AggregateName],
+                BatchId = Guid.Parse(domainEvent.Metadata[MetadataKeys.BatchId]),
+                Data = domainEvent.GetAggregateEvent(),
+                Metadata = domainEvent.Metadata,
+                AggregateSequenceNumber = domainEvent.AggregateSequenceNumber,
+                MessageId = new MessageId(domainEvent.Metadata[MetadataKeys.EventId]),
+                Topic = domainEvent.Metadata[MetadataKeys.AggregateName].ToSlug()
+            };
+        }
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/KafkaMessageFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaMessageFactory.cs
@@ -28,7 +28,7 @@ using System;
 
 namespace EventFlow.Kafka.Integrations
 {
-    class KafkaMessageFactory : IKafkaMessageFactory
+    public class KafkaMessageFactory : IKafkaMessageFactory
     {
         public KafkaMessage CreateMessage(IDomainEvent domainEvent)
         {

--- a/Source/EventFlow.Kafka/Integrations/KafkaProducerFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaProducerFactory.cs
@@ -26,7 +26,7 @@ using Confluent.Kafka;
 
 namespace EventFlow.Kafka.Integrations
 {
-    internal class KafkaProducerFactory : IKafkaProducerFactory
+    public class KafkaProducerFactory : IKafkaProducerFactory
     {
         private readonly ProducerConfig _config;
         public KafkaProducerFactory(ProducerConfig config)

--- a/Source/EventFlow.Kafka/Integrations/KafkaProducerFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaProducerFactory.cs
@@ -34,9 +34,9 @@ namespace EventFlow.Kafka.Integrations
             _config = config;
         }
 
-        public IProducer<string, KafkaMessage> CreateProducer()
+        public IProducer<string, string> CreateProducer()
         {
-            var builder = new ProducerBuilder<string, KafkaMessage>(_config);
+            var builder = new ProducerBuilder<string, string>(_config);
             return builder.Build();
         }
     }

--- a/Source/EventFlow.Kafka/Integrations/KafkaProducerFactory.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaProducerFactory.cs
@@ -1,0 +1,43 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Confluent.Kafka;
+
+
+namespace EventFlow.Kafka.Integrations
+{
+    internal class KafkaProducerFactory : IKafkaProducerFactory
+    {
+        private readonly ProducerConfig _config;
+        public KafkaProducerFactory(ProducerConfig config)
+        {
+            _config = config;
+        }
+
+        public IProducer<string, KafkaMessage> CreateProducer()
+        {
+            var builder = new ProducerBuilder<string, KafkaMessage>(_config);
+            return builder.Build();
+        }
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/KafkaPublisher.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaPublisher.cs
@@ -31,7 +31,7 @@ using System.Threading.Tasks;
 
 namespace EventFlow.Kafka.Integrations
 {
-    class KafkaPublisher : IKafkaPublisher
+    public class KafkaPublisher : IKafkaPublisher
     {
         private readonly ILog _log;
         private readonly IKafkaProducerFactory _producerFactory;

--- a/Source/EventFlow.Kafka/Integrations/KafkaPublisher.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaPublisher.cs
@@ -1,0 +1,104 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using Confluent.Kafka;
+using EventFlow.Core;
+using EventFlow.Logs;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventFlow.Kafka.Integrations
+{
+    class KafkaPublisher : IKafkaPublisher
+    {
+        private readonly ILog _log;
+        private readonly IKafkaProducerFactory _producerFactory;
+        private readonly ProducerConfig _configuration;
+        private readonly ITransientFaultHandler<IKafkaRetryStrategy> _transientFaultHandler;
+
+        public KafkaPublisher(ILog log,
+            IKafkaProducerFactory producerFactory,
+            ProducerConfig configuration,
+            ITransientFaultHandler<IKafkaRetryStrategy> transientFaultHandler)
+        {
+            _log = log;
+            _producerFactory = producerFactory;
+            _configuration = configuration;
+            _transientFaultHandler = transientFaultHandler;
+        }
+
+        public async Task PublishAsync(IReadOnlyCollection<KafkaMessage> kafkaMessages, CancellationToken cancellationToken)
+        {
+            try
+            {
+
+                await _transientFaultHandler.TryAsync(c => (
+                        ProduceMessages(kafkaMessages, c)),
+                            Label.Named("kafkas-publish"),
+                            cancellationToken)
+                    .ConfigureAwait(false);
+
+            }
+            catch (OperationCanceledException e)
+            {
+                _log.Error(e, "Failed to publish domain events to Kafka");
+                throw e;
+            }
+
+        }
+
+        private async Task ProduceMessages(IReadOnlyCollection<KafkaMessage> kafkaMessages, CancellationToken c)
+        {
+            var timeout = TimeSpan.FromMilliseconds(_configuration.TransactionTimeoutMs ?? 2000);
+
+            IProducer<string, KafkaMessage> kafkaProducer = null;
+            _log.Verbose(
+                    "Publishing {0} domain events to Kafka brokers '{1}'",
+                    kafkaMessages.Count, _configuration.BootstrapServers);
+
+            try
+            {
+                kafkaProducer = _producerFactory.CreateProducer();
+
+                kafkaProducer.BeginTransaction();
+                foreach (var message in kafkaMessages)
+                {
+                    var kafkaDomainMessage = new Message<string, KafkaMessage> { Value = message, Key = message.MessageId.Value };
+                    await kafkaProducer.ProduceAsync(message.Topic, kafkaDomainMessage, c);
+                }
+                kafkaProducer.CommitTransaction(timeout);
+            }
+            catch (Exception)
+            {
+                if (kafkaProducer != null)
+                {
+                    kafkaProducer.AbortTransaction(timeout);
+                    kafkaProducer.Dispose();
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/Source/EventFlow.Kafka/Integrations/KafkaRetryStrategy.cs
+++ b/Source/EventFlow.Kafka/Integrations/KafkaRetryStrategy.cs
@@ -1,0 +1,46 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using Confluent.Kafka;
+using EventFlow.Core;
+
+namespace EventFlow.Kafka.Integrations
+{
+    public class KafkaRetryStrategy : IKafkaRetryStrategy
+    {
+        private static readonly ISet<Type> TransientExceptions = new HashSet<Type>
+            {
+                typeof(ArgumentException),
+                typeof(ProduceException<string,KafkaMessage>)
+            };
+
+        public Retry ShouldThisBeRetried(Exception exception, TimeSpan totalExecutionTime, int currentRetryCount)
+        {
+            return currentRetryCount <= 3 && TransientExceptions.Contains(exception.GetType())
+                ? Retry.YesAfter(TimeSpan.FromMilliseconds(25))
+                : Retry.No;
+        }
+    }
+}

--- a/Source/EventFlow.Kafka/KafkaDomainEventPublisher.cs
+++ b/Source/EventFlow.Kafka/KafkaDomainEventPublisher.cs
@@ -1,0 +1,54 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using EventFlow.Aggregates;
+using EventFlow.Kafka.Integrations;
+using EventFlow.Subscribers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventFlow.Kafka
+{
+    public class KafkaDomainEventPublisher : ISubscribeSynchronousToAll
+    {
+        private IKafkaPublisher _KafkaPublisher { get; }
+        private IKafkaMessageFactory _KafkaMessageFactory { get; }
+        public KafkaDomainEventPublisher(IKafkaPublisher kafkaPublisher,
+            IKafkaMessageFactory kafkaMessageFactory)
+        {
+            _KafkaPublisher = kafkaPublisher;
+            _KafkaMessageFactory = kafkaMessageFactory;
+        }
+
+
+        public Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
+        {
+            var kafkaMessages = domainEvents.Select(e => _KafkaMessageFactory.CreateMessage(e)).ToList();
+
+            return _KafkaPublisher.PublishAsync(kafkaMessages, cancellationToken);
+        }
+    }
+}

--- a/Source/EventFlow.Kafka/KafkaDomainEventPublisher.cs
+++ b/Source/EventFlow.Kafka/KafkaDomainEventPublisher.cs
@@ -33,21 +33,21 @@ namespace EventFlow.Kafka
 {
     public class KafkaDomainEventPublisher : ISubscribeSynchronousToAll
     {
-        private IKafkaPublisher _KafkaPublisher { get; }
-        private IKafkaMessageFactory _KafkaMessageFactory { get; }
+        private IKafkaPublisher _kafkaPublisher { get; }
+        private IKafkaMessageFactory _kafkaMessageFactory { get; }
         public KafkaDomainEventPublisher(IKafkaPublisher kafkaPublisher,
             IKafkaMessageFactory kafkaMessageFactory)
         {
-            _KafkaPublisher = kafkaPublisher;
-            _KafkaMessageFactory = kafkaMessageFactory;
+            _kafkaPublisher = kafkaPublisher;
+            _kafkaMessageFactory = kafkaMessageFactory;
         }
 
 
         public Task HandleAsync(IReadOnlyCollection<IDomainEvent> domainEvents, CancellationToken cancellationToken)
         {
-            var kafkaMessages = domainEvents.Select(e => _KafkaMessageFactory.CreateMessage(e)).ToList();
+            var kafkaMessages = domainEvents.Select(e => _kafkaMessageFactory.CreateMessage(e)).ToList();
 
-            return _KafkaPublisher.PublishAsync(kafkaMessages, cancellationToken);
+            return _kafkaPublisher.PublishAsync(kafkaMessages, cancellationToken);
         }
     }
 }

--- a/Source/EventFlow.Kafka/KafkaDomainEventPublisher.cs
+++ b/Source/EventFlow.Kafka/KafkaDomainEventPublisher.cs
@@ -24,7 +24,6 @@
 using EventFlow.Aggregates;
 using EventFlow.Kafka.Integrations;
 using EventFlow.Subscribers;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/Source/EventFlow.Kafka/MessageId.cs
+++ b/Source/EventFlow.Kafka/MessageId.cs
@@ -1,0 +1,37 @@
+﻿// The MIT License (MIT)
+//
+// Copyright (c) 2020 Rasmus Mikkelsen
+// Copyright (c) 2020 eBay Software Foundation
+// https://github.com/rasmus/EventFlow
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using EventFlow.Core;
+using EventFlow.ValueObjects;
+
+namespace EventFlow.Kafka
+{
+    public class MessageId : SingleValueObject<string>, IIdentity
+    {
+        public MessageId(string value) : base(value)
+        {
+            if (string.IsNullOrEmpty(value)) throw new ArgumentNullException(nameof(value));
+        }
+    }
+}

--- a/Source/EventFlow.TestHelpers/Test.cs
+++ b/Source/EventFlow.TestHelpers/Test.cs
@@ -87,10 +87,12 @@ namespace EventFlow.TestHelpers
             return mock;
         }
 
-        protected IDomainEvent<ThingyAggregate, ThingyId> ADomainEvent<TAggregateEvent>(int aggregateSequenceNumber = 0)
+        protected IDomainEvent<ThingyAggregate, ThingyId> ADomainEvent<TAggregateEvent>(
+            int aggregateSequenceNumber = 0,
+            IDictionary<string, string> initMetadata = null)
             where TAggregateEvent : IAggregateEvent
         {
-            return ToDomainEvent(A<TAggregateEvent>(), aggregateSequenceNumber);
+            return ToDomainEvent(A<TAggregateEvent>(), aggregateSequenceNumber, initMetadata);
         }
 
         protected IReadOnlyCollection<IDomainEvent<ThingyAggregate, ThingyId>> ManyDomainEvents<TAggregateEvent>(
@@ -98,30 +100,37 @@ namespace EventFlow.TestHelpers
             where TAggregateEvent : IAggregateEvent
         {
             return Enumerable.Range(1, count)
-                .Select(ADomainEvent<TAggregateEvent>)
+                .Select(e => ADomainEvent<TAggregateEvent>(e))
                 .ToList();
         }
 
         protected IDomainEvent<ThingyAggregate, ThingyId> ToDomainEvent<TAggregateEvent>(
             TAggregateEvent aggregateEvent,
-            int aggregateSequenceNumber = 0)
+            int aggregateSequenceNumber = 0,
+            IDictionary<string, string> initMetadata = null)
             where TAggregateEvent : IAggregateEvent
         {
-            return ToDomainEvent(A<ThingyId>(), aggregateEvent, aggregateSequenceNumber);
+            return ToDomainEvent(A<ThingyId>(), aggregateEvent, aggregateSequenceNumber, initMetadata);
         }
 
         protected IDomainEvent<ThingyAggregate, ThingyId> ToDomainEvent<TAggregateEvent>(
             ThingyId thingyId,
             TAggregateEvent aggregateEvent,
-            int aggregateSequenceNumber = 0)
+            int aggregateSequenceNumber = 0,
+            IDictionary<string, string> initMetadata = null)
             where TAggregateEvent : IAggregateEvent
         {
-            var metadata = new Metadata
-                {
-                    Timestamp = A<DateTimeOffset>(),
-                    SourceId = A<SourceId>(),
-                    EventId = A<EventId>(),
-                };
+            IMetadata metadata = new Metadata
+            {
+                Timestamp = A<DateTimeOffset>(),
+                SourceId = A<SourceId>(),
+                EventId = A<EventId>()
+            };
+
+            if (initMetadata != null)
+            {
+                metadata = metadata.CloneWith(initMetadata);
+            }
 
             if (aggregateSequenceNumber == 0)
             {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -25,3 +25,29 @@ services:
     ports:
       - "1113:1113"
       - "2113:2113"
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.0
+    hostname: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:5.5.0
+    hostname: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -46,3 +46,29 @@ services:
       POSTGRES_PASSWORD: Password12!
     ports:
       - "5432:5432"
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.0
+    hostname: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:5.5.0
+    hostname: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0

--- a/up_integration-test-env.ps1
+++ b/up_integration-test-env.ps1
@@ -13,6 +13,8 @@ $env:RABBITMQ_URL = "amqp://guest:guest@localhost:5672"
 $env:ELASTICSEARCH_URL = "http://localhost:9200"
 # Event Store
 $env:EVENTSTORE_URL = "tcp://admin:changeit@localhost:1113"
+# Apache Kafka
+$env:KAFKA_URL = "localhost:9092"
 
 # Health checks
 # Event Store
@@ -21,3 +23,5 @@ curl --connect-timeout 60 --retry 5 -sL "http://localhost:2113"
 curl --connect-timeout 60 --retry 5 -sL "http://localhost:9200"
 # RabbitMQ
 curl --connect-timeout 60 --retry 5 -sL "http://localhost:15672"
+# Apache Kafka
+curl --connect-timeout 60 --retry 5 -sL "http://localhost:9092"


### PR DESCRIPTION
Related #465

Added an integration with Kafka using the `Confluent.Kafka` package.

I heavily followed the patterns established from the RabbitMq integration. At the moment, my testing has been limited to the integration testing that is included with this PR.

I would love to get some feedback, and discuss any changes that would need to be made in order for this integration to move forward.

#### Notes
* Due to the complexity of the Kafka configuration, I am leaking the Producer Configuration object out through the `IEventFlowOptions` builder:
    ```
    .PublishToKafka(new ProducerConfig { })
    ```
* In order to allow consumers to customize their partitioning scheme I am allowing the Kafka publisher to be configured with an optional `Func<IDomainEvent, TopicPartition> topicPartitionFactory`


